### PR TITLE
Adding missing vars to sound.yml

### DIFF
--- a/ansible/roles/ovos_installer/tasks/sound.yml
+++ b/ansible/roles/ovos_installer/tasks/sound.yml
@@ -29,6 +29,9 @@
     append: true
 
 - name: Add {{ ovos_installer_user }} to pipewire group
+  vars:
+    # Debian Unstable hack
+    _distribution_version: "{{ '99' if ansible_distribution == 'Debian' and ansible_distribution_version == 'n/a' else ansible_distribution_version }}"
   ansible.builtin.user:
     name: "{{ ovos_installer_user }}"
     groups:


### PR DESCRIPTION
Related to this issue: https://github.com/OpenVoiceOS/ovos-installer/issues/42

The sound.yml step `Add {{ ovos_installer_user }} to pipewire group` contains a condition requiring the var `_distribution_version`, which seems to be missing. I added this like it was done in the previous steps. 