### PR TITLE
[mark2] Address issue #99 about kernel version

### DIFF
--- a/ansible/roles/ovos_hardware_mark2/handlers/main.yml
+++ b/ansible/roles/ovos_hardware_mark2/handlers/main.yml
@@ -6,9 +6,12 @@
     daemon_reload: true
     scope: user
 
-- name: Load Module
+- name: Run Depmod
   ansible.builtin.command:
     cmd: |
       depmod -a {{ ansible_kernel }}
-      modprobe -v vocalfusion-soundcard
   changed_when: false
+
+- name: Set Reboot
+  ansible.builtin.set_fact:
+    ovos_installer_reboot: true

--- a/ansible/roles/ovos_hardware_mark2/handlers/main.yml
+++ b/ansible/roles/ovos_hardware_mark2/handlers/main.yml
@@ -6,8 +6,9 @@
     daemon_reload: true
     scope: user
 
-- name: Run Depmod
+- name: Load Module
   ansible.builtin.command:
     cmd: |
-      depmod -a {{ _ovos_hardware_mark2_kernel_target }}
+      depmod -a {{ ansible_kernel }}
+      modprobe -v vocalfusion-soundcard
   changed_when: false

--- a/ansible/roles/ovos_hardware_mark2/tasks/firmware.yml
+++ b/ansible/roles/ovos_hardware_mark2/tasks/firmware.yml
@@ -1,59 +1,4 @@
 ---
-# This block is only meaningful until kernel 6.6.22 becomes
-# the default Raspberry Pi stock kernel.
-# The current stock kernel version is 6.6.20 which does not work
-# with the VocalFusionDriver.
-# rpi-firmware commit f17defccf231912cfe96c9d3a779b4e2d006abd6 (6.6.22)
-- name: Block kernel upgrade
-  when: ansible_kernel is version("6.6.22", "<")
-  block:
-    - name: Kernel headers packages requirement
-      ansible.builtin.apt:
-        name:
-          - bc
-          - bison
-          - flex
-          - libssl-dev
-        install_recommends: false
-        update_cache: true
-
-    - name: Update kernel and firmware
-      ansible.builtin.shell:
-        cmd: |
-          set -o pipefail
-          echo y | rpi-update f17defccf231912cfe96c9d3a779b4e2d006abd6
-        executable: /bin/bash
-      environment:
-        SKIP_BACKUP: "1"
-        UPDATE_SELF: "1"
-      register: _firmware_status
-      changed_when: no
-
-    - name: Retrieve rpi-source Python script
-      ansible.builtin.get_url:
-        url: "{{ _ovos_hardware_mark2_rpi_source_url }}"
-        dest: /usr/local/bin/rpi-source
-        owner: root
-        group: root
-        mode: "0755"
-
-    - name: Build kernel headers
-      ansible.builtin.shell:
-        cmd: |
-          set -o pipefail
-          rpi-source -q --tag-update
-          echo -e -n "\r" | sudo rpi-source -d /usr/src/ --delete
-          ln -sf /usr/src/linux {{ _ovos_hardware_mark2_lib_modules_path }}/build
-        executable: /bin/bash
-      changed_when: no
-
-    - name: Set ovos_installer_reboot fact (firmware)
-      vars:
-        _firmware_reboot: "{{ _firmware_status.stdout | regex_search('reboot') }}"
-      ansible.builtin.set_fact:
-        ovos_installer_reboot: true
-      when: _firmware_status is defined and _firmware_reboot | length > 0
-
 - name: Install kernel headers
   ansible.builtin.apt:
     name: raspberrypi-kernel-headers
@@ -70,7 +15,7 @@
   ansible.builtin.command:
     cmd: rpi-eeprom-update -a
   register: _eeprom_status
-  changed_when: no
+  changed_when: false
 
 - name: Set ovos_installer_reboot fact (EEPROM)
   vars:

--- a/ansible/roles/ovos_hardware_mark2/tasks/vocalfusion.yml
+++ b/ansible/roles/ovos_hardware_mark2/tasks/vocalfusion.yml
@@ -48,7 +48,9 @@
     owner: root
     group: root
     mode: "0644"
-  notify: Load Module
+  notify:
+    - Run Depmod
+    - Set Reboot
 
 - name: Create /etc/modules-load.d/vocalfusion.conf file
   ansible.builtin.copy:
@@ -108,7 +110,6 @@
   ansible.builtin.systemd_service:
     name: sj201.service
     enabled: true
-    state: started
     force: true
     scope: user
 

--- a/ansible/roles/ovos_hardware_mark2/tasks/vocalfusion.yml
+++ b/ansible/roles/ovos_hardware_mark2/tasks/vocalfusion.yml
@@ -5,11 +5,6 @@
     dest: "{{ _ovos_hardware_mark2_vocalfusion_src_path }}"
     version: "{{ ovos_hardware_mark2_vocalfusion_branch }}"
 
-- name: Override variable for newer kernels
-  ansible.builtin.set_fact:
-    _ovos_hardware_mark2_lib_modules_path: "/lib/modules/{{ ansible_kernel }}"
-  when: ansible_kernel is version(_ovos_hardware_mark2_kernel_target, '>=')
-  
 - name: Copy DTBO files to /boot/overlays
   vars:
     _is_rpi5: "{{ '-pi5' if 'Raspberry Pi 5' in ovos_installer_raspberrypi else '' }}"
@@ -41,19 +36,19 @@
 - name: Build vocalfusion-soundcard.ko kernel module
   ansible.builtin.shell:
     cmd: |
-      sudo make -j {{ ansible_processor_count }} KDIR={{ _ovos_hardware_mark2_lib_modules_path }}/build all
+      sudo make -j {{ ansible_processor_count }} KDIR=/lib/modules/{{ ansible_kernel }}/build all
     executable: /bin/bash
     chdir: "{{ _ovos_hardware_mark2_vocalfusion_src_path }}/driver"
   changed_when: false
 
-- name: Copy vocalfusion-soundcard.ko to {{ _ovos_hardware_mark2_lib_modules_path }}
+- name: Copy vocalfusion-soundcard.ko to /lib/modules/{{ ansible_kernel }}
   ansible.builtin.copy:
     src: "{{ _ovos_hardware_mark2_vocalfusion_src_path }}/driver/vocalfusion-soundcard.ko"
-    dest: "{{ _ovos_hardware_mark2_lib_modules_path }}/vocalfusion-soundcard.ko"
+    dest: "/lib/modules/{{ ansible_kernel }}/vocalfusion-soundcard.ko"
     owner: root
     group: root
     mode: "0644"
-  notify: Run Depmod
+  notify: Load Module
 
 - name: Create /etc/modules-load.d/vocalfusion.conf file
   ansible.builtin.copy:
@@ -113,6 +108,7 @@
   ansible.builtin.systemd_service:
     name: sj201.service
     enabled: true
+    state: started
     force: true
     scope: user
 

--- a/ansible/roles/ovos_hardware_mark2/vars/main.yml
+++ b/ansible/roles/ovos_hardware_mark2/vars/main.yml
@@ -1,6 +1,2 @@
 ---
-# Until https://github.com/RPi-Distro/rpi-source/pull/29 PR is merged
-_ovos_hardware_mark2_rpi_source_url: https://raw.githubusercontent.com/jgartrel/rpi-source/master/rpi-source
-_ovos_hardware_mark2_kernel_target: "{{ '6.6.22-v8+' if 'Raspberry Pi 4' in ovos_installer_raspberrypi else '6.6.22-v8-16k+' }}"
-_ovos_hardware_mark2_lib_modules_path: "/lib/modules/{{ _ovos_hardware_mark2_kernel_target }}"
 _ovos_hardware_mark2_vocalfusion_src_path: /usr/src/vocalfusion


### PR DESCRIPTION
Since a kernel higher than 6.6.20 is now shipped by default with the Raspberry Pi OS image, there is no need for the hacky code in `firmware.yml`.


![image](https://github.com/OpenVoiceOS/ovos-installer/assets/614115/dd4f471a-9281-4efb-b115-6cf86e267fe6)
