### PR TITLE
Remove extraneous "the"

### DIFF
--- a/tui/locales/en-us/profiles.sh
+++ b/tui/locales/en-us/profiles.sh
@@ -1,7 +1,7 @@
 #!/bin/env bash
 
 CONTENT="
-To create a The versatile system that is suitable for many applications, there are three intriguing choices:
+To create a versatile system that is suitable for many applications, there are three intriguing choices:
 
   - Open Voice OS Master: The Open Voice OS classic experience
   - HiveMind Satellite: Open Voice OS audio components connected to HiveMind Listener


### PR DESCRIPTION
There's an extra "the" kicking around.

![image](https://github.com/user-attachments/assets/39c3d26c-0aa5-4aa9-9613-e20f81533f59)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Corrected a grammatical error in system choice descriptions for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->