### PR TITLE
adding support to almalinux

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Then follow the instructions display on screen.
 
 | Distribution        | Version   |
 | ------------------- | --------- |
+| AlmaLinux           | `>= 8`    |
 | Arch                | `rolling` |
 | CentOS              | `>= 8`    |
 | Debian GNU/Linux    | `>= 10`   |

--- a/tests/bats/packages.bats
+++ b/tests/bats/packages.bats
@@ -67,6 +67,15 @@ EOF
     assert_success
 }
 
+@test "function_required_packages_almalinux" {
+    DISTRO_NAME="almalinux"
+    function dnf() {
+        exit 0
+    }
+    run required_packages
+    assert_success
+}
+
 @test "function_required_packages_manjaro" {
     DISTRO_NAME="manjaro"
     function pacman() {

--- a/tests/bats/packages.bats
+++ b/tests/bats/packages.bats
@@ -184,6 +184,15 @@ EOF
     assert_failure
 }
 
+@test "function_required_packages_almalinux_fail" {
+    DISTRO_NAME="almalinux"
+    function dnf() {
+        exit 1
+    }
+    run required_packages
+    assert_failure
+}
+
 @test "function_required_packages_manjaro_fail" {
     DISTRO_NAME="manjaro"
     function pacman() {

--- a/utils/common.sh
+++ b/utils/common.sh
@@ -213,7 +213,7 @@ function required_packages() {
     fedora)
         dnf install -y python3 python3-devel python3-pip python3-virtualenv newt expect jq "${extra_packages[@]}" &>>"$LOG_FILE"
         ;;
-    rocky | centos)
+    almalinux | rocky | centos)
         dnf install -y python3 python3-devel python3-pip newt expect jq "${extra_packages[@]}" &>>"$LOG_FILE"
         ;;
     opensuse-tumbleweed | opensuse-leap)


### PR DESCRIPTION
Tested on my server with almalinux 9.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Expanded compatibility for package installation to include AlmaLinux, allowing users of this distribution to install necessary Python packages without issues.
  
- **Documentation**
	- Updated the compatibility table in the README to include AlmaLinux, clarifying support for version 8 and above.
  
- **Tests**
	- Added test cases to ensure the `required_packages` function works correctly with AlmaLinux in both successful and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->