### PR TITLE
[audio/template] Configure OCP when Mark II is detected

### DIFF
--- a/ansible/roles/ovos_installer/templates/mycroft.conf.j2
+++ b/ansible/roles/ovos_installer/templates/mycroft.conf.j2
@@ -25,6 +25,20 @@
     }
   },
 {% endif %}
+{% if 'tas5806' in ovos_installer_i2c_devices %}
+  "Audio": {
+    "backends": {
+      "OCP": {
+        "playback_mode": 40
+      }
+    }
+  },
+  "intents": {
+    "OCP": {
+      "legacy": true
+    }
+  },
+{% endif %}
 {% if ovos_installer_feature_gui | bool %}
   "gui": {
     "extension": "ovos-gui-plugin-shell-companion"{% if ovos_installer_method == "containers" %},


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced configuration options for the audio subsystem when the `tas5806` device is present, allowing for specific audio backend and intents settings.
	- Introduced conditional settings for "OCP" audio playback and intent configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->