### PR TITLE
[slowroll] Add openSUSE Slowroll support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Then follow the instructions display on screen.
 | Linux Mint          | `>= 21`   |
 | openSUSE Leap       | `>= 15`   |
 | openSUSE Tumbleweed | `rolling` |
+| openSUSE Slowroll   | `rolling` |
 | Manjaro             | `rolling` |
 | Raspbian            | `10`      |
 | Raspberry Pi OS     | `>= 11`   |

--- a/tests/bats/packages.bats
+++ b/tests/bats/packages.bats
@@ -112,6 +112,15 @@ EOF
     assert_success
 }
 
+@test "function_required_packages_opensuse_slowroll" {
+    DISTRO_NAME="opensuse-slowroll"
+    function zypper() {
+        exit 0
+    }
+    run required_packages
+    assert_success
+}
+
 @test "function_required_packages_linuxmint" {
     DISTRO_NAME="linuxmint"
     function apt-get() {
@@ -222,6 +231,15 @@ EOF
 
 @test "function_required_packages_opensuse_tumbleweed_fail" {
     DISTRO_NAME="opensuse-leap"
+    function zypper() {
+        exit 1
+    }
+    run required_packages
+    assert_failure
+}
+
+@test "function_required_packages_opensuse_slowroll_fail" {
+    DISTRO_NAME="opensuse-slowroll"
     function zypper() {
         exit 1
     }

--- a/utils/common.sh
+++ b/utils/common.sh
@@ -216,7 +216,7 @@ function required_packages() {
     almalinux | rocky | centos)
         dnf install -y python3 python3-devel python3-pip newt expect jq "${extra_packages[@]}" &>>"$LOG_FILE"
         ;;
-    opensuse-tumbleweed | opensuse-leap)
+    opensuse-tumbleweed | opensuse-leap | opensuse-slowroll)
         zypper install --no-recommends -y python3 python3-devel python3-pip python3-rpm newt expect jq "${extra_packages[@]}" &>>"$LOG_FILE"
         ;;
     arch | manjaro | endeavouros)


### PR DESCRIPTION
Implement https://github.com/OpenVoiceOS/ovos-installer/issues/118

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for "openSUSE Slowroll" in the documentation, enhancing clarity on supported systems.
  - Expanded the `required_packages` function to include package installation support for the "openSUSE Slowroll" distribution.

- **Tests**
  - Introduced two new test cases for handling the "openSUSE Slowroll" distribution in the test suite, improving test coverage.



<!-- end of auto-generated comment: release notes by coderabbit.ai -->