### PR TITLE
[ansible/docker] Make sure Docker GUI can run on stock Mark II

### DIFF
--- a/ansible/roles/ovos_installer/tasks/docker/composer.yml
+++ b/ansible/roles/ovos_installer/tasks/docker/composer.yml
@@ -42,8 +42,8 @@
     - { "file": "docker-compose.skills.yml", "state": "{{ 'false' if (ansible_memtotal_mb < 2048 and ovos_installer_profile != 'satellite' or not ovos_installer_feature_skills | bool) else 'true' }}" }
     - { "file": "docker-compose.skills-extra.yml", "state": "{{ 'false' if (ansible_memtotal_mb < 2048 and ovos_installer_profile != 'satellite' or not ovos_installer_feature_extra_skills | bool) else 'true' }}" }
     - { "file": "docker-compose.hivemind.yml", "state": "{{ 'true' if ovos_installer_profile == 'listener' else 'false' }}" }
-    - { "file": "docker-compose.gui.yml", "state": "{{ 'true' if (ansible_memtotal_mb >= 1740 and ovos_installer_profile != 'satellite' and ovos_installer_profile != 'server' and ovos_installer_feature_gui | bool) else 'false' }}" }
-    - { "file": "docker-compose.raspberrypi.gui.yml", "state": "{{ 'true' if (ansible_memtotal_mb >= 1740 and ovos_installer_profile != 'satellite' and ovos_installer_profile != 'server' and 'Raspberry Pi 4' in ovos_installer_raspberrypi and ovos_installer_feature_gui | bool) else 'false' }}" }
+    - { "file": "docker-compose.gui.yml", "state": "{{ 'true' if (ansible_memtotal_mb >= 1650 and ovos_installer_profile != 'satellite' and ovos_installer_profile != 'server' and ovos_installer_feature_gui | bool) else 'false' }}" }
+    - { "file": "docker-compose.raspberrypi.gui.yml", "state": "{{ 'true' if (ansible_memtotal_mb >= 1650 and ovos_installer_profile != 'satellite' and ovos_installer_profile != 'server' and 'Raspberry Pi 4' in ovos_installer_raspberrypi and ovos_installer_feature_gui | bool) else 'false' }}" }
     - { "file": "docker-compose.satellite.yml", "state": "{{ 'true' if ovos_installer_profile == 'satellite' else 'false' }}" }
     - { "file": "docker-compose.server.yml", "state": "{{ 'true' if ovos_installer_profile == 'server' else 'false' }}" }
   when: item.state | bool


### PR DESCRIPTION
Stock Mark II only has 2GB of RAM but depending the GPU memory allocation the memory available on the system could decrease below 1.7GB.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Adjusted memory requirements for enabling the graphical user interface (GUI) of the OVOS installer, allowing devices with 1650 MB of memory to utilize the GUI.
- **Bug Fixes**
	- Maintained existing profile-based restrictions to ensure consistent behavior for 'satellite' and 'server' profiles regarding GUI activation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->