### PR TITLE
[mark2] Add missing rpi-backlight overlay

### DIFF
--- a/ansible/roles/ovos_hardware_mark2/tasks/main.yml
+++ b/ansible/roles/ovos_hardware_mark2/tasks/main.yml
@@ -10,7 +10,6 @@
 
 - name: Include touchscreen.yml
   ansible.builtin.import_tasks: touchscreen.yml
-  when: "'attiny1614' in ovos_installer_i2c_devices"
 
 - name: Include wireplumber.yml
   ansible.builtin.import_tasks: wireplumber.yml

--- a/ansible/roles/ovos_hardware_mark2/tasks/touchscreen.yml
+++ b/ansible/roles/ovos_hardware_mark2/tasks/touchscreen.yml
@@ -1,4 +1,10 @@
 ---
+- name: Add rpi-backlight DT overlay
+  ansible.builtin.lineinfile:
+    path: "{{ _boot_directory }}/config.txt"
+    regexp: "^rpi-backlight"
+    line: "dtoverlay=rpi-backlight"
+
 - name: Manage touchscreen, DevKit vs Mark II
   ansible.builtin.lineinfile:
     path: "{{ _boot_directory }}/config.txt"
@@ -6,5 +12,6 @@
     line: "{{ item.overlay }}"
     state: "{{ item.state }}"
   loop:
-    - {"overlay": "dtoverlay=vc4-kms-v3d", "state": "absent" }
-    - {"overlay": "dtoverlay=vc4-fkms-v3d", "state": "present" }
+    - { "overlay": "dtoverlay=vc4-kms-v3d", "state": "absent" }
+    - { "overlay": "dtoverlay=vc4-fkms-v3d", "state": "present" }
+  when: "'attiny1614' in ovos_installer_i2c_devices"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Touchscreen-related tasks will now execute unconditionally, enhancing hardware compatibility.
	- Introduced a new task to configure a device tree overlay for the Raspberry Pi backlight, improving device functionality.

- **Bug Fixes**
	- Reformatted existing touchscreen overlay management tasks for better clarity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->