### PR TITLE
fix typo

### DIFF
--- a/ansible/roles/ovos_installer/tasks/virtualenv/gui.yml
+++ b/ansible/roles/ovos_installer/tasks/virtualenv/gui.yml
@@ -25,7 +25,7 @@
       - qtvirtualkeyboard-plugin
       - libqt5multimedia5
       - libqt5virtualkeyboard5
-      - breeze-icon-them
+      - breeze-icon-theme
   when: ansible_os_family in ['Debian', 'Zorin OS']
 
 - name: Install package requirements for ovos-gui
@@ -53,7 +53,7 @@
       - kf5-kiconthemes
       - kf5-kiconthemes-devel
       - kf5-kguiaddons-devel
-      - breeze-icon-them
+      - breeze-icon-theme
   when: ansible_os_family == "RedHat"
 
 - name: Install package requirements for ovos-gui


### PR DESCRIPTION
closes https://github.com/OpenVoiceOS/ovos-installer/issues/138

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected the spelling of the package name from "breeze-icon-them" to "breeze-icon-theme" to ensure accurate installation across supported operating systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->