### PR TITLE
[tui/method] Set default method to virtualenv

### DIFF
--- a/tui/methods.sh
+++ b/tui/methods.sh
@@ -4,7 +4,7 @@
 source "tui/locales/$LOCALE/methods.sh"
 
 declare -a available_methods
-active_method="containers"
+active_method="virtualenv"
 available_methods=(containers virtualenv)
 
 # When 32-bit CPU is detected, the only method available


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Changed the default method for script execution from "containers" to "virtualenv," enhancing the user experience by prioritizing the preferred method.
  
- **Bug Fixes**
	- Addressed potential issues related to the default method selection, ensuring smoother operation in various environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->