### PR TITLE
fix #141

### DIFF
--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -35,7 +35,7 @@
         - ansible_architecture == "aarch64"
         - ansible_distribution_major_version is version('11', '>=')
         - "'Raspberry Pi 4' in ovos_installer_raspberrypi or 'Raspberry Pi 5' in ovos_installer_raspberrypi"
-        
+
     - role: ovos_installer
 
   tasks:

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -24,18 +24,18 @@
     - role: ovos_hardware_mark1
       when:
         - ansible_distribution == "Debian"
-        - ansible_distribution_major_version is version('11', '>=')
         - "'atmega328p' in ovos_installer_i2c_devices"
         - ansible_architecture == "aarch64"
+        - ansible_distribution_major_version is version('11', '>=')
 
     - role: ovos_hardware_mark2
       when:
         - ansible_distribution == "Debian"
-        - ansible_distribution_major_version is version('11', '>=')
-        - "'Raspberry Pi 4' in ovos_installer_raspberrypi or 'Raspberry Pi 5' in ovos_installer_raspberrypi"
         - "'tas5806' in ovos_installer_i2c_devices"
         - ansible_architecture == "aarch64"
-
+        - ansible_distribution_major_version is version('11', '>=')
+        - "'Raspberry Pi 4' in ovos_installer_raspberrypi or 'Raspberry Pi 5' in ovos_installer_raspberrypi"
+        
     - role: ovos_installer
 
   tasks:


### PR DESCRIPTION
moving the check on the version of ansible AFTER the check on raspberry, avoid to break the role as the checks are in sequential order

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Improvements**
	- Enhanced consistency in the execution conditions for hardware roles based on the Debian version, ensuring tasks are only applied when the system meets the specified criteria.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->