### PR TITLE
[Draft] Installer Improvements

### DIFF
--- a/ansible/roles/ovos_installer/tasks/tuning/governor.yml
+++ b/ansible/roles/ovos_installer/tasks/tuning/governor.yml
@@ -1,4 +1,5 @@
 ---
+# Commented out as a hacky workaround. Not sure why it is failing
 #- name: Handle linux-cpupower package
 #  ansible.builtin.apt:
 #    name: "{{ 'cpupower' if ansible_distribution != 'Debian' else 'linux-cpupower' }}"

--- a/ansible/roles/ovos_installer/tasks/tuning/governor.yml
+++ b/ansible/roles/ovos_installer/tasks/tuning/governor.yml
@@ -1,12 +1,12 @@
 ---
-- name: Handle linux-cpupower package
-  ansible.builtin.apt:
-    name: "{{ 'cpupower' if ansible_distribution != 'Debian' else 'linux-cpupower' }}"
-    install_recommends: false
-    state: "{{ ovos_installer_uninstall }}"
-  when: ansible_os_family == "Debian"
-  tags:
-    - always
+#- name: Handle linux-cpupower package
+#  ansible.builtin.apt:
+#    name: "{{ 'cpupower' if ansible_distribution != 'Debian' else 'linux-cpupower' }}"
+#    install_recommends: false
+#    state: "{{ ovos_installer_uninstall }}"
+#  when: ansible_os_family == "Debian"
+#  tags:
+#    - always
 
 - name: Handle kernel-toolsr package
   ansible.builtin.dnf:

--- a/installer.sh
+++ b/installer.sh
@@ -3,11 +3,10 @@
 # Set global variables based on sudo usage
 if [ -n "$SUDO_USER" ]; then
     export RUN_AS="$SUDO_USER"
-    export RUN_AS_HOME="/home/$SUDO_USER"
 else
     export RUN_AS=$USER
-    export RUN_AS_HOME="/$SUDO_USER"
 fi
+export RUN_AS_HOME=$(eval echo ~"$RUN_AS")
 
 # Check for git command to be installed
 if ! command -v git &>/dev/null; then

--- a/utils/argparse.sh
+++ b/utils/argparse.sh
@@ -7,8 +7,11 @@ function usage() {
     echo "  -h, --help          Display this help message"
     echo "  -d, --debug         Enable debug mode for more verbosity"
     echo "  -u, --uninstall     Uninstall Open Voice OS instance"
+    echo "  --reuse-cached-artifacts   [Developer option] avoids removing files which can lead to faster iteration times "
     echo
 }
+
+export USE_UV="true"
 
 # Parse the arguments passed to the command line.
 # We are not using getopts as it only handles short arguments
@@ -26,6 +29,9 @@ function handle_options() {
         -h | --help)
             usage
             exit 0
+            ;;
+        --reuse-cached-artifacts)
+            export REUSED_CACHED_ARTIFACTS="true"
             ;;
         *)
             echo "Invalid option: $1" >&2

--- a/utils/common.sh
+++ b/utils/common.sh
@@ -327,7 +327,9 @@ function create_python_venv() {
 
     if [ "$USE_UV" == "true" ]; then
         export PIP_COMMAND="uv pip"
-        pip3 install uv -U
+        if ! type uv ; then
+            pip3 install "uv>=0.4.10"
+        fi
     else
         export PIP_COMMAND="pip3"
     fi

--- a/utils/common.sh
+++ b/utils/common.sh
@@ -303,6 +303,7 @@ function create_python_venv() {
         fi
     fi
 
+    echo "VENV_PATH = $VENV_PATH"
     if [ ! -d "$VENV_PATH" ]; then
 
         if [ "$USE_UV" == "true" ]; then
@@ -320,10 +321,10 @@ function create_python_venv() {
     source "$VENV_PATH/bin/activate"
 
     if [ "$USE_UV" == "true" ]; then
-        export PIP_COMMAND="python3 -m uv pip"
-        python3 -m pip install uv -U
+        export PIP_COMMAND="python -m uv pip"
+        python -m pip install uv -U
     else
-        export PIP_COMMAND="python3 -m pip3"
+        export PIP_COMMAND="python -m pip"
     fi
 
     $PIP_COMMAND install --upgrade pip setuptools &>>"$LOG_FILE"

--- a/utils/common.sh
+++ b/utils/common.sh
@@ -39,13 +39,12 @@ function detect_user() {
         # sudo user
         export RUN_AS="$SUDO_USER"
         export RUN_AS_UID="$SUDO_UID"
-        export RUN_AS_HOME="/home/$SUDO_USER"
     else
         # root user
         export RUN_AS="$USER"
         export RUN_AS_UID="$EUID"
-        export RUN_AS_HOME="/$RUN_AS"
     fi
+    export RUN_AS_HOME=$(eval echo ~"$RUN_AS")
     export VENV_PATH="${RUN_AS_HOME}/.venvs/${INSTALLER_VENV_NAME}"
 }
 


### PR DESCRIPTION
There are some parts of the installer that seems very slow. If the user already has all of the apt packages, the installer still does an update and attempts to install them, which causes unnecessary wait.

Main ideas:

* Use `dpkg -l` to detect if a package already is installed on debian-based systems. This is codified in the `apt_ensure` function, which is ported from my bash utils.
* Use `uv` instead of pip when possible. It is much faster. I'm making this option configurable.  

This is a draft PR where I'm exploring ways to speed up and otherwise improve the installer script.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced a new function, `apt_ensure`, to streamline package management by checking and installing missing packages.
	- Added a command-line option `--reuse-cached-artifacts` to enhance developer workflow.

- **Improvements**
	- Enhanced the accuracy of the `RUN_AS_HOME` environment variable assignment for users running the installer script with `sudo`.
	- Updated package installation process to reduce unnecessary `sudo` calls.

- **Bug Fixes**
	- Improved reliability in determining the home directory for both root and sudo users.
	- Commented out a task related to managing the `linux-cpupower` package to address an unspecified failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->