### PR TITLE
Rename REUSED_CACHED_ARTIFACTS->REUSE_CACHED_ARTIFACTS

### DIFF
--- a/utils/argparse.sh
+++ b/utils/argparse.sh
@@ -43,9 +43,9 @@ function handle_options() {
     # significantly faster.
     export USE_UV="${USE_UV:-true}"
 
-    # If REUSED_CACHED_ARTIFACTS is true, keep any existing ansible venv which
+    # If REUSE_CACHED_ARTIFACTS is true, keep any existing ansible venv which
     # speeds up the installer, but could result in errors if it is in a dirty
     # state. This is mainly useful when debugging the installer.
-    export REUSED_CACHED_ARTIFACTS="${REUSED_CACHED_ARTIFACTS:-false}"
+    export REUSE_CACHED_ARTIFACTS="${REUSE_CACHED_ARTIFACTS:-false}"
 }
 

--- a/utils/common.sh
+++ b/utils/common.sh
@@ -244,7 +244,7 @@ function create_python_venv() {
     fi
 
     if [ -d "$VENV_PATH" ]; then
-        if [ "$REUSED_CACHED_ARTIFACTS" != "true" ]; then
+        if [ "$REUSE_CACHED_ARTIFACTS" != "true" ]; then
             # Make sure everything is clean before starting.
             rm -rf "$VENV_PATH" /root/.ansible &>>"$LOG_FILE"
         fi


### PR DESCRIPTION
Not a big deal, but I just noticed that the variable name `REUSED_CACHED_ARTIFACTS` should have been `REUSE_CACHED_ARTIFACTS` to indicate it is modifying a future behavior and not reflecting the measurement of something that had been done. Figure its better to rename it quickly before anyone starts to use it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Renamed variable for clarity and consistency related to caching artifacts.
	- Updated conditional logic to reflect the new variable name in the virtual environment setup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->