### PR TITLE
[ansible/templates] Use SOX player for wav and mp3 by default

### DIFF
--- a/ansible/roles/ovos_installer/templates/mycroft.conf.j2
+++ b/ansible/roles/ovos_installer/templates/mycroft.conf.j2
@@ -7,8 +7,8 @@
   },
 {% endif %}
 {% if ovos_installer_profile != "server" %}
-  "play_wav_cmdline": "{{ 'aplay' if _detect_sound_server.stdout == "pulseaudio" else 'pw-play' }} %1",
-  "play_mp3_cmdline": "{{ 'paplay' if _detect_sound_server.stdout == "pulseaudio" else 'pw-play' }} %1",
+  "play_wav_cmdline": "play %1",
+  "play_mp3_cmdline": "play %1",
   "lang": "{{ ovos_installer_locale }}",
   "listener": {
     "remove_silence": true,


### PR DESCRIPTION
SOX is capable of handling `wav` and `mp3` files which make it easier to manager rather than having a combination of `aplay`, `paplay`, `pw-play`, etc...