### PR TITLE
[ansible/venv] Use a wrapper for ovos-phal-admin systemd unit

### DIFF
--- a/ansible/roles/ovos_installer/tasks/virtualenv/systemd.yml
+++ b/ansible/roles/ovos_installer/tasks/virtualenv/systemd.yml
@@ -1,4 +1,13 @@
 ---
+- name: Copy wrapper-ovos-phal-admin.sh file
+  ansible.builtin.template:
+    src: virtualenv/wrapper-ovos-phal-admin.sh.j2
+    dest: /usr/local/bin/wrapper-ovos-phal-admin.sh
+    owner: root
+    group: root
+    mode: "0755"
+  when: ovos_installer_profile != 'satellite' and ovos_installer_profile != 'server'
+
 - name: Copy OVOS systemd unit files
   vars:
     _path_user: "{{ ovos_installer_user_home }}/.config/systemd/user"

--- a/ansible/roles/ovos_installer/templates/virtualenv/ovos-phal-admin.service.j2
+++ b/ansible/roles/ovos_installer/templates/virtualenv/ovos-phal-admin.service.j2
@@ -7,8 +7,7 @@ After=network-online.target
 Environment=XDG_CONFIG_HOME={{ ovos_installer_user_home }}/.config
 Environment=XDG_CACHE_HOME={{ ovos_installer_user_home }}/.cache
 WorkingDirectory={{ ovos_installer_user_home }}/.venvs/ovos
-ExecStart={{ ovos_installer_user_home }}/.venvs/ovos/bin/ovos_PHAL_admin
-ExecStartPost=/usr/bin/chown {{ ovos_installer_user }}: -R /tmp/combo_locks
+ExecStart=/usr/local/bin/wrapper-ovos-phal-admin.sh
 ExecReload=/usr/bin/kill -s HUP $MAINPID
 ExecStop=/usr/bin/kill -s KILL $MAINPID
 Restart=on-failure

--- a/ansible/roles/ovos_installer/templates/virtualenv/wrapper-ovos-phal-admin.sh.j2
+++ b/ansible/roles/ovos_installer/templates/virtualenv/wrapper-ovos-phal-admin.sh.j2
@@ -4,9 +4,9 @@
 # requirements are fulfilled before trying to start.
 
 # Variables
-combo_locks_path=/tmp/combo_locks
+combo_locks_path=${COMBO_LOCKS_PATH:-/tmp/combo_locks}
 attempt_counter=0
-max_attempt=10
+max_attempt=${MAX_ATTEMPT:-10}
 
 # Wait for other OVOS compoenents to start, if /tmp/combo_locks
 # directory is not created by other components then ovos-phal-admin

--- a/ansible/roles/ovos_installer/templates/virtualenv/wrapper-ovos-phal-admin.sh.j2
+++ b/ansible/roles/ovos_installer/templates/virtualenv/wrapper-ovos-phal-admin.sh.j2
@@ -8,15 +8,15 @@ combo_locks_path=/tmp/combo_locks
 attempt_counter=0
 max_attempt=10
 
-# Wait for other OVOS compoenents to start
+# Wait for other OVOS compoenents to start, if /tmp/combo_locks
+# directory is not created by other components then ovos-phal-admin
+# will not start as a deeper issue exists.
 while ! [ -d "$combo_locks_path" ]; do
     if [ "$attempt_counter" -lt "$max_attempt" ]; then
-        echo "Trying to start ovos-phal-admin systemd unit... Attempt ${attempt_counter}/${max_attempt}"
         ((attempt_counter++))
+        echo "Trying to start ovos-phal-admin systemd unit... Attempt ${attempt_counter}/${max_attempt}"
         sleep 1
     fi
-    mkdir "$combo_locks_path"
-    chown {{ ovos_installer_user }}: -R "$combo_locks_path"
 done
 
 # Starst ovos_PHAL_admin Python binary

--- a/ansible/roles/ovos_installer/templates/virtualenv/wrapper-ovos-phal-admin.sh.j2
+++ b/ansible/roles/ovos_installer/templates/virtualenv/wrapper-ovos-phal-admin.sh.j2
@@ -1,0 +1,23 @@
+#!/bin/bash
+#
+# This script ensure that all OVOS PHAL admin service
+# requirements are fulfilled before trying to start.
+
+# Variables
+combo_locks_path=/tmp/combo_locks
+attempt_counter=0
+max_attempt=10
+
+# Wait for other OVOS compoenents to start
+while ! [ -d "$combo_locks_path" ]; do
+    if [ "$attempt_counter" -lt "$max_attempt" ]; then
+        echo "Trying to start ovos-phal-admin systemd unit... Attempt ${attempt_counter}/${max_attempt}"
+        ((attempt_counter++))
+        sleep 1
+    fi
+    mkdir "$combo_locks_path"
+    chown {{ ovos_installer_user }}: -R "$combo_locks_path"
+done
+
+# Starst ovos_PHAL_admin Python binary
+{{ ovos_installer_user_home }}/.venvs/ovos/bin/ovos_PHAL_admin


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new script (`wrapper-ovos-phal-admin.sh`) to ensure prerequisites for the OVOS PHAL admin service are met before startup.
  - Updated the systemd service configuration for the OVOS PHAL Admin to use the new wrapper script.

- **Improvements**
  - Enhanced service management by refining conditions for service enabling and uninstallation based on the installation profile. 

- **Bug Fixes**
  - Removed outdated commands from the systemd service configuration to streamline operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->