### PR TITLE
[ansible/venv] Comment eastereggs skill until PR is merged

### DIFF
--- a/ansible/roles/ovos_installer/templates/virtualenv/extra-skills-requirements.txt.j2
+++ b/ansible/roles/ovos_installer/templates/virtualenv/extra-skills-requirements.txt.j2
@@ -4,6 +4,6 @@ ovos-skill-icanhazdadjokes
 # No PyPi release
 git+https://github.com/OpenVoiceOS/skill-ovos-randomness.git
 
-{% if ovos_installer_profile != "server" %}
-git+https://github.com/OpenVoiceOS/ovos-skill-easter-eggs.git
-{% endif %}
+#{% if ovos_installer_profile != "server" %}
+#git+https://github.com/OpenVoiceOS/ovos-skill-easter-eggs.git
+#{% endif %}


### PR DESCRIPTION
Commenting the skill installation until this https://github.com/OpenVoiceOS/ovos-skill-easter-eggs/pull/47 got merged as it downgrade `ovos-core` to 2.3.0 which doesn't contain the fallback match https://github.com/OpenVoiceOS/ovos-core/pull/572