### PR TITLE
[ansible/venv] Fix potential wrapper race condition

### DIFF
--- a/ansible/roles/ovos_installer/templates/virtualenv/wrapper-ovos-phal-admin.sh.j2
+++ b/ansible/roles/ovos_installer/templates/virtualenv/wrapper-ovos-phal-admin.sh.j2
@@ -20,8 +20,20 @@ while ! [ -d "$combo_locks_path" ]; do
         # If for some reasons /tmp/combo_locks is not created by the other
         # services then we force the directory creation with the
         # correct permissions to avoid a potential race condition.
-        mkdir -p "$combo_locks_path"
-        chown -R {{ ovos_installer_user }}:{{ ovos_installer_group }} "$combo_locks_path"
+        if ! mkdir -p "$combo_locks_path"; then
+            echo "Failed to create $combo_locks_path directory" >&2
+            exit 1
+        fi
+        if ! chmod 755 "$combo_locks_path" || \
+           ! chown -R {{ ovos_installer_user }}:{{ ovos_installer_group }} "$combo_locks_path"; then
+            echo "Failed to set permissions on $combo_locks_path" >&2
+            exit 1
+        fi
+        # Verify directory exists and has correct ownership
+        if [ ! -d "$combo_locks_path" ]; then
+            echo "Directory creation verification failed" >&2
+            exit 1
+        fi
     fi
 done
 

--- a/ansible/roles/ovos_installer/templates/virtualenv/wrapper-ovos-phal-admin.sh.j2
+++ b/ansible/roles/ovos_installer/templates/virtualenv/wrapper-ovos-phal-admin.sh.j2
@@ -16,6 +16,12 @@ while ! [ -d "$combo_locks_path" ]; do
         ((attempt_counter++))
         echo "Trying to start ovos-phal-admin systemd unit... Attempt ${attempt_counter}/${max_attempt}"
         sleep 1
+    else
+        # If for some reasons /tmp/combo_locks is not created by the other
+        # services then we force the directory creation with the
+        # correct permissions to avoid a potential race condition.
+        mkdir -p "$combo_locks_path"
+        chown -R {{ ovos_installer_user }}:{{ ovos_installer_group }} "$combo_locks_path"
     fi
 done
 


### PR DESCRIPTION
Closes https://github.com/OpenVoiceOS/ovos-installer/issues/196

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of the `/tmp/combo_locks` directory to prevent race conditions.
	- Corrected a typo in the comment regarding the start of the `ovos_PHAL_admin` Python binary.

- **Chores**
	- Ensured proper directory creation and ownership settings for smoother service startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->