### PR TITLE
[ansible/venv] Enable virtual keyboard when Mark II or DevKit detected

### DIFF
--- a/ansible/roles/ovos_installer/templates/virtualenv/ovos-gui.service.j2
+++ b/ansible/roles/ovos_installer/templates/virtualenv/ovos-gui.service.j2
@@ -16,6 +16,9 @@ Environment="QT_QPA_EGLFS_HIDECURSOR=1"
 Environment="QT_QPA_EGLFS_INTEGRATION=eglfs_kms"
 Environment="QT_QPA_EGLFS_KMS_CONFIG=%h/.config/ovos-eglfs.json"
 {% endif %}
+{% if 'tas5806' in ovos_installer_i2c_devices %}
+Environment="QT_IM_MODULE=qtvirtualkeyboard"
+{% endif %}
 WorkingDirectory=%h/.venvs/ovos
 ExecStart=/usr/bin/{{ 'ovos-shell' if ovos_installer_display_server == "N/A" else 'ovos-gui-app' }}
 ExecReload=/usr/bin/kill -s HUP $MAINPID


### PR DESCRIPTION
Fix https://github.com/OpenVoiceOS/ovos-installer/issues/207

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a conditional environment variable for the `ovos-gui` service to enable virtual keyboard integration when the specified I2C device is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->