### PR TITLE
[ansible/tuning] Enable NUMA for Raspberry Pi 4 and 5

### DIFF
--- a/ansible/roles/ovos_installer/tasks/tuning/main.yml
+++ b/ansible/roles/ovos_installer/tasks/tuning/main.yml
@@ -28,3 +28,7 @@
 
 - name: Include tuning/fstab.yml
   ansible.builtin.import_tasks: tuning/fstab.yml
+
+- name: Include tuning/numa.yml
+  ansible.builtin.import_tasks: tuning/numa.yml
+  when: "'Raspberry Pi 4' in ovos_installer_raspberrypi or 'Raspberry Pi 5' in ovos_installer_raspberrypi"

--- a/ansible/roles/ovos_installer/tasks/tuning/numa.yml
+++ b/ansible/roles/ovos_installer/tasks/tuning/numa.yml
@@ -1,0 +1,12 @@
+---
+- name: Enable NUMA for Raspberry Pi 4 & 5
+  vars:
+    _fake_number: "{{ '4' if 'Raspberry Pi 5' in ovos_installer_raspberrypi else '2' }}"
+  ansible.builtin.lineinfile:
+    path: "{{ _boot_directory }}/cmdline.txt"
+    regexp: "^((?!.*{{ item }}).*console.*)$"
+    line: '\1 {{ item }}'
+    backrefs: true
+  loop:
+    - "numa=fake={{ _fake_number }}"
+    - numa_policy=interleave


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new task for tuning configurations specifically for Raspberry Pi 4 and 5 devices.
	- Added support for enabling NUMA (Non-Uniform Memory Access) for improved performance on Raspberry Pi devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->