### PR TITLE
[ansible/ovos] Create .config/hivemind when not ovos profile

### DIFF
--- a/ansible/roles/ovos_installer/tasks/ovos.yml
+++ b/ansible/roles/ovos_installer/tasks/ovos.yml
@@ -57,6 +57,7 @@
     state: directory
   loop:
     - { "directory": "{{ ovos_installer_user_home }}/.config/mycroft", "status": true }
+    - { "directory": "{{ ovos_installer_user_home }}/.config/hivemind", "status": "{{ 'false' if ovos_installer_profile == 'ovos' else 'true' }}" }
     - { "directory": "{{ ovos_installer_user_home }}/.config/systemd/user", "status": true }
     - { "directory": "{{ ovos_installer_user_home }}/nltk_data", "status": true }
   when:


### PR DESCRIPTION
Fix https://github.com/OpenVoiceOS/ovos-installer/issues/226

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced conditional logic for directory creation based on installation profiles.
	- Introduced a backup mechanism for existing configurations during uninstallation.

- **Bug Fixes**
	- Improved handling of directory creation to prevent conflicts with specific profiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->