### PR TITLE
[ansible/venv] Use PyPi packages instead of GitHub

### DIFF
--- a/ansible/roles/ovos_installer/templates/virtualenv/listener-requirements.txt.j2
+++ b/ansible/roles/ovos_installer/templates/virtualenv/listener-requirements.txt.j2
@@ -1,3 +1,3 @@
-hivemind_bus_client
-HiveMind-presence
-jarbas-hive-mind
+hivemind-bus-client
+hivemind-core
+hivemind-presence

--- a/ansible/roles/ovos_installer/templates/virtualenv/satellite-requirements.txt.j2
+++ b/ansible/roles/ovos_installer/templates/virtualenv/satellite-requirements.txt.j2
@@ -1,3 +1,5 @@
+hivemind-bus-client
+hivemind-voice-sat
 ovos-audio[extras]
 ovos-classifiers
 ovos-dinkum-listener[extras,linux]
@@ -20,7 +22,3 @@ ovos-PHAL[mk1]
 {% if 'tas5806' in ovos_installer_i2c_devices %}
 ovos-PHAL[mk2]
 {% endif %}
-
-# No PyPi release
-git+https://github.com/JarbasHiveMind/HiveMind-voice-sat.git
-git+https://github.com/JarbasHiveMind/hivemind_websocket_client.git

--- a/ansible/roles/ovos_installer/templates/virtualenv/server-requirements.txt.j2
+++ b/ansible/roles/ovos_installer/templates/virtualenv/server-requirements.txt.j2
@@ -1,7 +1,7 @@
-# HiveMind (no PyPi release)
-git+https://github.com/JarbasHiveMind/HiveMind-core.git
-git+https://github.com/JarbasHiveMind/HiveMind-presence.git
-git+https://github.com/JarbasHiveMind/hivemind_websocket_client.git
+# HiveMind
+hivemind-bus-client
+hivemind-core
+hivemind-presence
 
 # OVOS
 ovos-core[lgpl,plugins]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced new dependencies for enhanced functionality, including `hivemind-bus-client`, `hivemind-voice-sat`, and `ovos-audio[extras]`.
  - Conditional dependencies added based on locale and CPU capability.

- **Bug Fixes**
  - Removed outdated GitHub repository references for certain dependencies.

- **Documentation**
  - Updated naming conventions for dependencies to improve consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->