### PR TITLE
[ansible] Use official module since PR got merged

### DIFF
--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -9,4 +9,4 @@ collections:
   - name: kewlfft.aur
     version: 0.11.1
   - name: moreati.uv
-    src: git+https://github.com/goldyfruit/ansible-uv
+    version: 0.0.3


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated Ansible collection `moreati.uv` to version 0.0.3, changing the installation method from source-based to version-based.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->