### PR TITLE
[ansible/sound] Closes #238

### DIFF
--- a/ansible/roles/ovos_installer/handlers/main.yml
+++ b/ansible/roles/ovos_installer/handlers/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Start Sound Server
-  ansible.builtin.import_tasks: block-sound.yml
+  ansible.builtin.include_tasks: block-sound.yml
 
 - name: Reload Systemd User
   become: true


### PR DESCRIPTION
Cause by https://github.com/ansible/ansible/pull/61060/files
Introduced by https://github.com/OpenVoiceOS/ovos-installer/commit/ad05dc6cba888bffa96995d5f4900ebed4fff949

Closes as well https://github.com/OpenVoiceOS/ovos-installer/issues/233

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated task processing method for sound server initialization to use dynamic task inclusion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->