### PR TITLE
[ansible/ovos] Make sure directory exists priot backup

### DIFF
--- a/ansible/roles/ovos_installer/tasks/ovos.yml
+++ b/ansible/roles/ovos_installer/tasks/ovos.yml
@@ -14,6 +14,14 @@
   tags:
     - uninstall
 
+- name: Check if directory to backup exists
+  ansible.builtin.stat:
+    path: "{{ ovos_directories_backup }}"
+  register: _ovos_installer_directory_exists
+  when: ovos_installer_cleaning | bool
+  tags:
+    - uninstall
+
 - name: Backup existing configurations before uninstall
   community.general.archive:
     path: "{{ ovos_directories_backup }}"
@@ -23,7 +31,9 @@
     mode: "0755"
     format: gz
     force_archive: true
-  when: ovos_installer_cleaning | bool
+  when:
+    - ovos_installer_cleaning | bool
+    - _ovos_installer_directory_exists.stat.exists | bool
   tags:
     - uninstall
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved backup process reliability by adding directory existence checks before performing backups.
	- Enhanced error handling to prevent unnecessary backup operations when target directories are missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->