### PR TITLE
[utils/common] Check only for ovos_core and ovos_messagebus 

### DIFF
--- a/utils/common.sh
+++ b/utils/common.sh
@@ -147,10 +147,10 @@ function detect_cpu_instructions() {
 # the Python virtual environement.
 function detect_existing_instance() {
     echo -ne "➤ Checking for existing instance... "
-    if [ -n "$(docker ps -a --filter="name=ovos*|hivemind*" -q 2>>"$LOG_FILE")" ]; then
+    if [ -n "$(docker ps -a --filter="name=ovos_core|ovos_messagebus|hivemind*" -q 2>>"$LOG_FILE")" ]; then
         export EXISTING_INSTANCE="true"
         export INSTANCE_TYPE="containers"
-    elif [ -n "$(podman ps -a --filter="name=ovos*|hivemind*" -q 2>>"$LOG_FILE")" ]; then
+    elif [ -n "$(podman ps -a --filter="name=ovos_core|ovos_messagebus|hivemind*" -q 2>>"$LOG_FILE")" ]; then
         export EXISTING_INSTANCE="true"
         export INSTANCE_TYPE="containers"
     elif [ -d "${RUN_AS_HOME}/.venvs/ovos" ]; then


### PR DESCRIPTION
if other containers with `ovos` in the name exists then the installer will ask for uninstall even if OVOS has been uninstalled. This might be due to containers such as `ovos_stt*`, `ovos_tts*`, etc...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved container detection mechanism for Docker and Podman
	- Refined filtering of existing Open Voice OS instances

<!-- end of auto-generated comment: release notes by coderabbit.ai -->