### PR TITLE
[ansible/venv] Set Rust messagebus as default

### DIFF
--- a/ansible/roles/ovos_installer/tasks/ovos.yml
+++ b/ansible/roles/ovos_installer/tasks/ovos.yml
@@ -47,15 +47,33 @@
     mode: "0755"
     state: directory
   loop:
-    - { "directory": "{{ ovos_installer_user_home }}/.config/systemd/user", "status": true }
-    - { "directory": "{{ ovos_installer_user_home }}/ovos", "status": true }
-    - { "directory": "{{ ovos_installer_user_home }}/ovos/config", "status": true }
-    - { "directory": "{{ ovos_installer_user_home }}/ovos/config/phal", "status": true }
-    - { "directory": "{{ ovos_installer_user_home }}/ovos/share", "status": true }
-    - { "directory": "{{ ovos_installer_user_home }}/ovos/tmp", "status": true }
-    - { "directory": "{{ ovos_installer_user_home }}/hivemind", "status": "{{ 'false' if (ovos_installer_profile == 'ovos' and ovos_installer_profile == 'server') else 'true' }}" }
-    - { "directory": "{{ ovos_installer_user_home }}/hivemind/config", "status": "{{ 'false' if (ovos_installer_profile == 'ovos' and ovos_installer_profile == 'server') else 'true' }}" }
-    - { "directory": "{{ ovos_installer_user_home }}/hivemind/share", "status": "{{ 'false' if (ovos_installer_profile == 'ovos' and ovos_installer_profile == 'server') else 'true' }}" }
+    - {
+        "directory": "{{ ovos_installer_user_home }}/.config/systemd/user",
+        "status": true,
+      }
+    - {"directory": "{{ ovos_installer_user_home }}/ovos", "status": true}
+    - {
+        "directory": "{{ ovos_installer_user_home }}/ovos/config",
+        "status": true,
+      }
+    - {
+        "directory": "{{ ovos_installer_user_home }}/ovos/config/phal",
+        "status": true,
+      }
+    - {"directory": "{{ ovos_installer_user_home }}/ovos/share", "status": true}
+    - {"directory": "{{ ovos_installer_user_home }}/ovos/tmp", "status": true}
+    - {
+        "directory": "{{ ovos_installer_user_home }}/hivemind",
+        "status": "{{ 'false' if (ovos_installer_profile == 'ovos' and ovos_installer_profile == 'server') else 'true' }}",
+      }
+    - {
+        "directory": "{{ ovos_installer_user_home }}/hivemind/config",
+        "status": "{{ 'false' if (ovos_installer_profile == 'ovos' and ovos_installer_profile == 'server') else 'true' }}",
+      }
+    - {
+        "directory": "{{ ovos_installer_user_home }}/hivemind/share",
+        "status": "{{ 'false' if (ovos_installer_profile == 'ovos' and ovos_installer_profile == 'server') else 'true' }}",
+      }
   when:
     - item.status | bool
     - ovos_installer_method == "containers"
@@ -68,11 +86,24 @@
     mode: "0755"
     state: directory
   loop:
-    - { "directory": "{{ ovos_installer_user_home }}/.config/mycroft", "status": true }
-    - { "directory": "{{ ovos_installer_user_home }}/.local/state/mycroft", "status": true }
-    - { "directory": "{{ ovos_installer_user_home }}/.config/hivemind", "status": "{{ 'false' if ovos_installer_profile == 'ovos' else 'true' }}" }
-    - { "directory": "{{ ovos_installer_user_home }}/.config/systemd/user", "status": true }
-    - { "directory": "{{ ovos_installer_user_home }}/nltk_data", "status": true }
+    - {
+        "directory": "{{ ovos_installer_user_home }}/.config/mycroft",
+        "status": true,
+      }
+    - {
+        "directory": "{{ ovos_installer_user_home }}/.local/state/mycroft",
+        "status": true,
+      }
+    - {"directory": "{{ ovos_installer_user_home }}/.local/bin", "status": true}
+    - {
+        "directory": "{{ ovos_installer_user_home }}/.config/hivemind",
+        "status": "{{ 'false' if ovos_installer_profile == 'ovos' else 'true' }}",
+      }
+    - {
+        "directory": "{{ ovos_installer_user_home }}/.config/systemd/user",
+        "status": true,
+      }
+    - {"directory": "{{ ovos_installer_user_home }}/nltk_data", "status": true}
   when:
     - item.status | bool
     - ovos_installer_method == "virtualenv"

--- a/ansible/roles/ovos_installer/tasks/virtualenv/bus.yml
+++ b/ansible/roles/ovos_installer/tasks/virtualenv/bus.yml
@@ -1,0 +1,14 @@
+---
+- name: Download and extract Rust messagebus
+  vars:
+    _ovos_rust_bus_repo: https://github.com/OscillateLabsLLC/ovos-rust-messagebus
+    _ovos_rust_bus_version: v1.1.0
+    _ovos_rust_bus_archive_name: "ovos_messagebus-{{ ansible_architecture }}-unknown-linux-gnu.tar.gz"
+    _ovos_rust_bus_url: "{{ _ovos_rust_bus_repo }}/releases/download/{{ _ovos_rust_bus_version }}/{{ _ovos_rust_bus_archive_name}}"
+  ansible.builtin.unarchive:
+    src: "{{ _ovos_rust_bus_url }}"
+    dest: "{{ ovos_installer_user_home }}/.local/bin"
+    mode: "0755"
+    owner: "{{ ovos_installer_user }}"
+    group: "{{ ovos_installer_group }}"
+    remote_src: true

--- a/ansible/roles/ovos_installer/tasks/virtualenv/main.yml
+++ b/ansible/roles/ovos_installer/tasks/virtualenv/main.yml
@@ -9,5 +9,8 @@
   ansible.builtin.import_tasks: virtualenv/gui.yml
   when: ovos_installer_feature_gui | bool or ovos_installer_cleaning | bool
 
+- name: Include virtualenv/bus.yml
+  ansible.builtin.import_tasks: virtualenv/bus.yml
+
 - name: Include virtualenv/systemd.yml
   ansible.builtin.import_tasks: virtualenv/systemd.yml

--- a/ansible/roles/ovos_installer/tasks/virtualenv/venv.yml
+++ b/ansible/roles/ovos_installer/tasks/virtualenv/venv.yml
@@ -185,7 +185,7 @@
 
 - name: Remove {{ ovos_installer_user_home }}/.venvs/ovos Python virtualenv and requirements.txt files
   ansible.builtin.file:
-    path: "{{ ovos_installer_user_home }}/.venvs/ovos"
+    path: "{{ item }}"
     state: absent
   loop:
     - "{{ ovos_installer_user_home }}/.venvs/ovos"
@@ -198,6 +198,7 @@
     - /tmp/server-requirements.txt
     - /opt/mark1
     - /opt/sj201
+    - "{{ ovos_installer_user_home }}/.local/bin/ovos-messagebus"
   when: ovos_installer_cleaning | bool
   tags:
     - uninstall

--- a/ansible/roles/ovos_installer/templates/virtualenv/core-requirements.txt.j2
+++ b/ansible/roles/ovos_installer/templates/virtualenv/core-requirements.txt.j2
@@ -2,7 +2,6 @@ ovos-audio[extras]
 ovos-core[lgpl,plugins]
 ovos-dinkum-listener[extras,linux]
 ovos-docs-viewer
-ovos-messagebus
 ovos-PHAL[linux]
 ovos-phal-plugin-ipgeo
 ovos-tts-plugin-polly
@@ -31,4 +30,3 @@ ovos-PHAL[mk1]
 ovos-PHAL[mk2dev]
 git+https://github.com/OVOSHatchery/ovos-PHAL-plugin-sj201-leds.git
 {% endif %}
-

--- a/ansible/roles/ovos_installer/templates/virtualenv/ovos-messagebus.service.j2
+++ b/ansible/roles/ovos_installer/templates/virtualenv/ovos-messagebus.service.j2
@@ -5,8 +5,7 @@ PartOf=ovos.service
 Requires=ovos.service
 
 [Service]
-WorkingDirectory=%h/.venvs/ovos
-ExecStart=%h/.venvs/ovos/bin/ovos-messagebus
+ExecStart=%h/.local/bin/ovos_messagebus-{{ ansible_architecture }}-unknown-linux-gnu
 ExecReload=/usr/bin/kill -s HUP $MAINPID
 ExecStop=/usr/bin/kill -s KILL $MAINPID
 Restart=on-failure

--- a/ansible/roles/ovos_installer/templates/virtualenv/server-requirements.txt.j2
+++ b/ansible/roles/ovos_installer/templates/virtualenv/server-requirements.txt.j2
@@ -5,4 +5,3 @@ hivemind-presence
 
 # OVOS
 ovos-core[lgpl,plugins]
-ovos-messagebus


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features  
  - Introduced a new installer step that downloads and extracts a Rust-based message bus, now integrated into the virtual environment setup.

- Chores  
  - Improved installer readability and expanded directory creation to support additional user binaries.  
  - Enhanced cleanup routines to remove extra temporary files and configurations.  
  - Updated the service configuration with revised executable paths and streamlined the installation requirements by removing the now redundant message bus dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->