### PR TITLE
[ansible/ovos] Make sure .local belongs to user

### DIFF
--- a/ansible/roles/ovos_installer/tasks/ovos.yml
+++ b/ansible/roles/ovos_installer/tasks/ovos.yml
@@ -91,7 +91,7 @@
         "status": true,
       }
     - {
-        "directory": "{{ ovos_installer_user_home }}/.local/state/mycroft",
+        "directory": "{{ ovos_installer_user_home }}/.local",
         "status": true,
       }
     - {"directory": "{{ ovos_installer_user_home }}/.local/bin", "status": true}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Streamlined the backup process and directory handling to enhance the uninstallation routine.

- **Refactor**
  - Adjusted the conditions for checking and creating directories to ensure a consistent configuration setup during installation and uninstallation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->