### PR TITLE
[ansible/venv] Remove hivemind-presence as its breaks with LXML

### DIFF
--- a/ansible/roles/ovos_installer/templates/virtualenv/listener-requirements.txt.j2
+++ b/ansible/roles/ovos_installer/templates/virtualenv/listener-requirements.txt.j2
@@ -1,3 +1,2 @@
 hivemind-bus-client
 hivemind-core
-hivemind-presence


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Streamlined our dependency setup by removing an outdated package, reducing potential conflicts and maintenance overhead. All core functionalities continue unchanged with essential dependencies, ensuring a robust, highly efficient environment. This release is part of our ongoing efforts to enhance system performance and reliability, thereby significantly improving the overall user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->