### PR TITLE
[ansible/venv] ONNXRuntime 1.21.0 breaks the listener

### DIFF
--- a/ansible/roles/ovos_installer/templates/virtualenv/core-requirements.txt.j2
+++ b/ansible/roles/ovos_installer/templates/virtualenv/core-requirements.txt.j2
@@ -30,3 +30,6 @@ ovos-PHAL[mk1]
 ovos-PHAL[mk2dev]
 git+https://github.com/OVOSHatchery/ovos-PHAL-plugin-sj201-leds.git
 {% endif %}
+
+# Tempoary fix since ONNXRuntime 1.21.0 breaks ovos-dinkum-listener
+onnxruntime==1.20.1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Implemented a temporary update to a key dependency, ensuring compatibility with recent external package changes. This update resolves an issue that could have impacted the reliability of certain voice command features, thereby providing a more stable user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->