### PR TITLE
[ansible/venv] Add Galician and Basque support

### DIFF
--- a/ansible/roles/ovos_installer/templates/virtualenv/core-requirements.txt.j2
+++ b/ansible/roles/ovos_installer/templates/virtualenv/core-requirements.txt.j2
@@ -10,6 +10,10 @@ ovos-tts-plugin-polly
 ovos-tts-plugin-matxa-multispeaker-cat
 {% endif %}
 
+{% if ovos_installer_locale == "gl-es" %}
+ovos-tts-plugin-nos
+{% endif %}
+
 {% if (ansible_architecture == "x86_64") or (ansible_architecture == "aarch64") %}
 ovos-audio-transformer-plugin-ggwave
 {% endif %}

--- a/ansible/roles/ovos_installer/templates/virtualenv/satellite-requirements.txt.j2
+++ b/ansible/roles/ovos_installer/templates/virtualenv/satellite-requirements.txt.j2
@@ -11,6 +11,10 @@ ovos-tts-plugin-polly
 ovos-tts-plugin-matxa-multispeaker-cat
 {% endif %}
 
+{% if ovos_installer_locale == "gl-es" %}
+ovos-tts-plugin-nos
+{% endif %}
+
 {% if ovos_installer_cpu_is_capable | bool %}
 ovos-dinkum-listener[onnx]
 {% endif %}

--- a/tui/language.sh
+++ b/tui/language.sh
@@ -33,5 +33,5 @@ fi
 
 # Hash of locales
 declare -A locales
-locales=(["english"]="en-us" ["french"]="fr-fr" ["german"]="de-de" ["italian"]="it-it" ["spanish"]="es-es" ["dutch"]="nl-nl" ["portuguese"]="pt-pt" ["hindi"]="hi-in" ["catalan"]="ca-es")
+locales=(["catalan"]="ca-es" ["english"]="en-us" ["french"]="fr-fr" ["galitian"]="gl-es" ["german"]="de-de" ["hindi"]="hi-in" ["italian"]="it-it" ["spanish"]="es-es" ["dutch"]="nl-nl" ["portuguese"]="pt-pt")
 export LOCALE="${locales[$language]}"


### PR DESCRIPTION
Not fully implemented as Cotovia is only supports Debian and Arch distribution as well as only `x86_64` CPU architecture.