### PR TITLE
fix: restore support for python < 3.10

### DIFF
--- a/ansible/roles/ovos_installer/templates/virtualenv/core-requirements.txt.j2
+++ b/ansible/roles/ovos_installer/templates/virtualenv/core-requirements.txt.j2
@@ -42,5 +42,3 @@ ovos-PHAL[mk2dev]
 git+https://github.com/OVOSHatchery/ovos-PHAL-plugin-sj201-leds.git
 {% endif %}
 
-# Tempoary fix since ONNXRuntime 1.21.0 breaks ovos-dinkum-listener
-onnxruntime==1.20.1


### PR DESCRIPTION
onnxruntime is now properly pinned in dinkum listener

```
failed: [127.0.0.1] (item={'file': '/tmp/core-requirements.txt', 'state': True}) => {"ansible_loop_var": "item", "attempts": 5, "changed": false, "cmd": ["/home/pablo/.venvs/ovos-installer/bin/uv", "pip", "install", "-U", "--python", "/home/pablo/.venvs/ovos/bin/python", "--pre", "-r", "/tmp/core-requirements.txt"], "item": {"file": "/tmp/core-requirements.txt", "state": true}, "msg": "\n:stderr: Using Python 3.9.16 environment at: /home/pablo/.venvs/ovos\n × No solution found when resolving dependencies:\n ╰─▶ Because onnxruntime==1.20.1 has no wheels with a matching Python\n implementation tag (e.g., cp39) and you require onnxruntime==1.20.1,\n we can conclude that your requirements are unsatisfiable.\n\n hint: You require CPython 3.9 (cp39), but we only found wheels for\n onnxruntime (v1.20.1) with the following Python implementation tags:\n cp310, cp311, cp312, cp313\n"}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed the explicit dependency on a specific ONNXRuntime version to streamline our installation configuration.  
  - This update cleans up the dependency management, which may impact components relying on the previously fixed version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->