### PR TITLE
[ansible/venv] Remove ovos-classifiers from satellite

### DIFF
--- a/ansible/roles/ovos_installer/templates/virtualenv/satellite-requirements.txt.j2
+++ b/ansible/roles/ovos_installer/templates/virtualenv/satellite-requirements.txt.j2
@@ -1,7 +1,6 @@
 hivemind-bus-client
 hivemind-voice-sat
 ovos-audio[extras]
-ovos-classifiers
 ovos-dinkum-listener[extras,linux]
 ovos-PHAL[linux]
 ovos-phal-plugin-ipgeo


### PR DESCRIPTION
Removing `ovos-classifiers` from HiveMind Satellite as it might become an issue.
https://github.com/OpenVoiceOS/ovos-installer/issues/292