### PR TITLE
[utils/common] Add support for Pop!_OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ sudo sh -c "$(curl -fsSL https://raw.githubusercontent.com/OpenVoiceOS/ovos-inst
 | openSUSE Leap       | `>= 15`   |
 | openSUSE Tumbleweed | `rolling` |
 | openSUSE Slowroll   | `rolling` |
-| Pop!_OS            | `>=22.04` |
+| Pop!_OS             | `>=22.04` |
 | Manjaro             | `rolling` |
 | Raspbian            | `10`      |
 | Raspberry Pi OS     | `>= 11`   |

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ sudo sh -c "$(curl -fsSL https://raw.githubusercontent.com/OpenVoiceOS/ovos-inst
 | openSUSE Leap       | `>= 15`   |
 | openSUSE Tumbleweed | `rolling` |
 | openSUSE Slowroll   | `rolling` |
+| Pop!\_OS            | `>=22.04` |
 | Manjaro             | `rolling` |
 | Raspbian            | `10`      |
 | Raspberry Pi OS     | `>= 11`   |

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ sudo sh -c "$(curl -fsSL https://raw.githubusercontent.com/OpenVoiceOS/ovos-inst
 | openSUSE Leap       | `>= 15`   |
 | openSUSE Tumbleweed | `rolling` |
 | openSUSE Slowroll   | `rolling` |
-| Pop!\_OS            | `>=22.04` |
+| Pop!_OS            | `>=22.04` |
 | Manjaro             | `rolling` |
 | Raspbian            | `10`      |
 | Raspberry Pi OS     | `>= 11`   |

--- a/tests/bats/packages.bats
+++ b/tests/bats/packages.bats
@@ -22,6 +22,15 @@ EOF
     assert_success
 }
 
+@test "function_required_packages_popos" {
+    DISTRO_NAME="pop"
+    function apt-get() {
+        exit 0
+    }
+    run required_packages
+    assert_success
+}
+
 @test "function_required_packages_raspbian" {
     DISTRO_NAME="raspbian"
     function apt-get() {
@@ -141,6 +150,15 @@ EOF
 
 @test "function_required_packages_debian_fail" {
     DISTRO_NAME="debian"
+    function apt-get() {
+        exit 1
+    }
+    run required_packages
+    assert_failure
+}
+
+@test "function_required_packages_popos_fail" {
+    DISTRO_NAME="pop"
     function apt-get() {
         exit 1
     }

--- a/utils/common.sh
+++ b/utils/common.sh
@@ -243,7 +243,7 @@ function required_packages() {
     fi
 
     case "$DISTRO_NAME" in
-    debian | ubuntu | raspbian | linuxmint | zorin | neon)
+    debian | ubuntu | raspbian | linuxmint | zorin | neon | pop)
         UPDATE=1 apt_ensure python3 python3-dev python3-pip python3-venv whiptail expect jq "${extra_packages[@]}" &>>"$LOG_FILE"
         ;;
     fedora)


### PR DESCRIPTION
Fix https://github.com/OpenVoiceOS/ovos-installer/issues/294

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the README to include Pop!_OS (version 22.04 or higher) as a supported Linux distribution.

- **Tests**
  - Added new test cases to ensure proper package installation handling for Pop!_OS, covering both success and failure scenarios.

- **Bug Fixes**
  - Improved compatibility by recognizing Pop!_OS as a supported Debian-based distribution for package installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->