### PR TITLE
[ansible/venv] Force 1.26.4 version of numpy

### DIFF
--- a/ansible/roles/ovos_installer/tasks/virtualenv/venv.yml
+++ b/ansible/roles/ovos_installer/tasks/virtualenv/venv.yml
@@ -65,6 +65,11 @@
     extra_args: "--trusted-host whl.smartgic.io -f 'https://whl.smartgic.io'"
   when: ansible_architecture == "aarch64" or ansible_architecture == "x86_64"
 
+- name: Force numpy==1.26.4 Python library
+  moreati.uv.pip:
+    name: numpy==1.26.4
+    virtualenv: "{{ ovos_installer_user_home }}/.venvs/ovos"
+
 - name: Install Open Voice OS in Python venv
   vars:
     _pip_args: "{{ '--pre' if ovos_installer_channel == 'development' else '' }}"


### PR DESCRIPTION
```
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]: 2025-06-17 15:28:53.681 - voice - ovos_ww_plugin_precise_lite:download_model:56 - INFO - Model downloaded to /home/goldyfruit/.local/share/precise-lite/hey_mycroft.tflite
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]: A module that was compiled using NumPy 1.x cannot be run in
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]: NumPy 2.3.0 as it may crash. To support both 1.x and 2.x
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]: versions of NumPy, modules must be compiled with NumPy 2.0.
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]: Some module may need to rebuild instead e.g. with 'pybind11>=2.12'.
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]: If you are a user of the module, the easiest solution will be to
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]: downgrade to 'numpy<2' or try to upgrade the affected module.
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]: We expect that some modules will need time to support NumPy 2.
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]: Traceback (most recent call last):  File "/home/goldyfruit/.venvs/ovos/bin/ovos-dinkum-listener", line 10, in <module>
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]:     sys.exit(main())
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]:   File "/home/goldyfruit/.venvs/ovos/lib/python3.11/site-packages/ovos_dinkum_listener/__main__.py", line 25, in main
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]:     service.run()
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]:   File "/home/goldyfruit/.venvs/ovos/lib/python3.11/site-packages/ovos_dinkum_listener/service.py", line 338, in run
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]:     self._start()
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]:   File "/home/goldyfruit/.venvs/ovos/lib/python3.11/site-packages/ovos_dinkum_listener/service.py", line 381, in _start
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]:     self.hotwords.load_hotword_engines()
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]:   File "/home/goldyfruit/.venvs/ovos/lib/python3.11/site-packages/ovos_dinkum_listener/voice_loop/hotwords.py", line 171, in load_hotword_engines
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]:     engine = OVOSWakeWordFactory.create_hotword(word)
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]:   File "/home/goldyfruit/.venvs/ovos/lib/python3.11/site-packages/ovos_plugin_manager/wakewords.py", line 163, in create_hotword
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]:     return cls.load_module(module, hotword, ww_config)
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]:   File "/home/goldyfruit/.venvs/ovos/lib/python3.11/site-packages/ovos_plugin_manager/wakewords.py", line 145, in load_module
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]:     return clazz(hotword, hotword_config)
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]:   File "/home/goldyfruit/.venvs/ovos/lib/python3.11/site-packages/ovos_ww_plugin_precise_lite/__init__.py", line 35, in __init__
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]:     self.runner = PreciseLiteListener(model=self.precise_model,
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]:   File "/home/goldyfruit/.venvs/ovos/lib/python3.11/site-packages/precise_lite_runner/__init__.py", line 15, in __init__
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]:     self.listener = Listener(model, chunk_size)
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]:   File "/home/goldyfruit/.venvs/ovos/lib/python3.11/site-packages/precise_lite_runner/runner.py", line 63, in __init__
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]:     self.runner = TFLiteRunner(model_name)
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]:   File "/home/goldyfruit/.venvs/ovos/lib/python3.11/site-packages/precise_lite_runner/runner.py", line 25, in __init__
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]:     self.interpreter = tflite.Interpreter(model_path=model_name)
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]:   File "/home/goldyfruit/.venvs/ovos/lib/python3.11/site-packages/tflite_runtime/interpreter.py", line 464, in __init__
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]:     self._interpreter = _interpreter_wrapper.CreateWrapperFromFile(
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]: AttributeError: _ARRAY_API not found
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]: 2025-06-17 15:28:53.707 - voice - ovos_plugin_manager.wakewords:create_hotword:165 - ERROR - Failed to load hotword: hey_mycroft - ovos-ww-plugin-precise-lite
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]: 2025-06-17 15:28:53.709 - voice - ovos_plugin_manager.wakewords:create_hotword:166 - ERROR - <built-in method CreateWrapperFromFile of PyCapsule object at 0x7fa031bb40> returned a result with an exception set
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]: ImportError: numpy.core.multiarray failed to import
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]: The above exception was the direct cause of the following exception:
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]: Traceback (most recent call last):
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]:   File "/home/goldyfruit/.venvs/ovos/lib/python3.11/site-packages/ovos_plugin_manager/wakewords.py", line 163, in create_hotword
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]:     return cls.load_module(module, hotword, ww_config)
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]:   File "/home/goldyfruit/.venvs/ovos/lib/python3.11/site-packages/ovos_plugin_manager/wakewords.py", line 145, in load_module
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]:     return clazz(hotword, hotword_config)
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]:   File "/home/goldyfruit/.venvs/ovos/lib/python3.11/site-packages/ovos_ww_plugin_precise_lite/__init__.py", line 35, in __init__
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]:     self.runner = PreciseLiteListener(model=self.precise_model,
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]:                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]:   File "/home/goldyfruit/.venvs/ovos/lib/python3.11/site-packages/precise_lite_runner/__init__.py", line 15, in __init__
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]:     self.listener = Listener(model, chunk_size)
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]:                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]:   File "/home/goldyfruit/.venvs/ovos/lib/python3.11/site-packages/precise_lite_runner/runner.py", line 63, in __init__
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]:     self.runner = TFLiteRunner(model_name)
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]:                   ^^^^^^^^^^^^^^^^^^^^^^^^
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]:   File "/home/goldyfruit/.venvs/ovos/lib/python3.11/site-packages/precise_lite_runner/runner.py", line 25, in __init__
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]:     self.interpreter = tflite.Interpreter(model_path=model_name)
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]:                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]:   File "/home/goldyfruit/.venvs/ovos/lib/python3.11/site-packages/tflite_runtime/interpreter.py", line 464, in __init__
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]:     self._interpreter = _interpreter_wrapper.CreateWrapperFromFile(
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]:                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]: SystemError: <built-in method CreateWrapperFromFile of PyCapsule object at 0x7fa031bb40> returned a result with an exception set
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]: 2025-06-17 15:28:53.712 - voice - ovos_plugin_manager.wakewords:create_hotword:169 - INFO - Attempting to load fallback ww instead: hey_mycroft_precise
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]: 2025-06-17 15:28:53.716 - voice - ovos_plugin_manager.wakewords:load_module:137 - INFO - Loading "hey_mycroft_precise" wake word via ovos-ww-plugin-precise with config: {'module': 'ovos-ww-plugin-precise', 'version': '0.3', 'model': 'https://github.com/MycroftAI/precise-data/raw/models-dev/hey-mycroft.tar.gz', 'expected_duration': 3, 'trigger_level': 3, 'sensitivity': 0.5, 'listen': True, 'fallback_ww': 'hey_mycroft_vosk'}
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]: 2025-06-17 15:28:53.897 - voice - ovos_plugin_manager.utils:load_plugin:177 - WARNING - Could not find the plugin PluginTypes.WAKEWORD.ovos-ww-plugin-precise
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]: 2025-06-17 15:28:53.899 - voice - ovos_plugin_manager.wakewords:create_hotword:165 - ERROR - Failed to load hotword: hey_mycroft_precise - ovos-ww-plugin-precise
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]: 2025-06-17 15:28:53.901 - voice - ovos_plugin_manager.wakewords:create_hotword:166 - ERROR - Wake Word hey_mycroft_precise with module ovos-ww-plugin-precise failed to load
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]: ImportError: numpy.core.multiarray failed to import
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]: The above exception was the direct cause of the following exception:
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]: Traceback (most recent call last):
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]:   File "/home/goldyfruit/.venvs/ovos/lib/python3.11/site-packages/ovos_plugin_manager/wakewords.py", line 163, in create_hotword
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]:     return cls.load_module(module, hotword, ww_config)
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]:   File "/home/goldyfruit/.venvs/ovos/lib/python3.11/site-packages/ovos_plugin_manager/wakewords.py", line 145, in load_module
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]:     return clazz(hotword, hotword_config)
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]:   File "/home/goldyfruit/.venvs/ovos/lib/python3.11/site-packages/ovos_ww_plugin_precise_lite/__init__.py", line 35, in __init__
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]:     self.runner = PreciseLiteListener(model=self.precise_model,
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]:                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]:   File "/home/goldyfruit/.venvs/ovos/lib/python3.11/site-packages/precise_lite_runner/__init__.py", line 15, in __init__
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]:     self.listener = Listener(model, chunk_size)
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]:                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]:   File "/home/goldyfruit/.venvs/ovos/lib/python3.11/site-packages/precise_lite_runner/runner.py", line 63, in __init__
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]:     self.runner = TFLiteRunner(model_name)
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]:                   ^^^^^^^^^^^^^^^^^^^^^^^^
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]:   File "/home/goldyfruit/.venvs/ovos/lib/python3.11/site-packages/precise_lite_runner/runner.py", line 25, in __init__
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]:     self.interpreter = tflite.Interpreter(model_path=model_name)
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]:                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]:   File "/home/goldyfruit/.venvs/ovos/lib/python3.11/site-packages/tflite_runtime/interpreter.py", line 464, in __init__
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]:     self._interpreter = _interpreter_wrapper.CreateWrapperFromFile(
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]:                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]: SystemError: <built-in method CreateWrapperFromFile of PyCapsule object at 0x7fa031bb40> returned a result with an exception set
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]: During handling of the above exception, another exception occurred:
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]: Traceback (most recent call last):
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]:   File "/home/goldyfruit/.venvs/ovos/lib/python3.11/site-packages/ovos_plugin_manager/wakewords.py", line 163, in create_hotword
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]:     return cls.load_module(module, hotword, ww_config)
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]:   File "/home/goldyfruit/.venvs/ovos/lib/python3.11/site-packages/ovos_plugin_manager/wakewords.py", line 142, in load_module
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]:     raise ImportError(f'Wake Word {hotword} with module {module} '
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]: ImportError: Wake Word hey_mycroft_precise with module ovos-ww-plugin-precise failed to load
Jun 17 15:28:53 mark2 ovos-dinkum-listener[14531]: 2025-06-17 15:28:53.904 - voice - ovos_plugin_manager.wakewords:create_hotword:169 - INFO - Attempting to load fallback ww instead: hey_mycroft_vosk
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Ensured that the Python library numpy (version 1.26.4) is installed in the virtual environment prior to other requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->