### PR TITLE
Fix/satellite profile

### DIFF
--- a/ansible/roles/ovos_installer/tasks/virtualenv/venv.yml
+++ b/ansible/roles/ovos_installer/tasks/virtualenv/venv.yml
@@ -69,7 +69,7 @@
   vars:
     _pip_args: "{{ '--pre' if ovos_installer_channel == 'development' else '' }}"
     _ovos_release: "https://raw.githubusercontent.com/OpenVoiceOS/ovos-releases/refs/heads/main/constraints-{{ ovos_installer_channel }}.txt"
-    _pip_constraints: "--constraint {{ _ovos_release if ovos_installer_profile != 'satellite' else '' }}"
+    _pip_constraints: "{{ '--constraint ' + _ovos_release if ovos_installer_profile != 'satellite' else '' }}"
   moreati.uv.pip:
     requirements: "{{ item.file }}"
     virtualenv: "{{ ovos_installer_user_home }}/.venvs/ovos"

--- a/ansible/roles/ovos_installer/tasks/virtualenv/venv.yml
+++ b/ansible/roles/ovos_installer/tasks/virtualenv/venv.yml
@@ -67,13 +67,12 @@
 
 - name: Install Open Voice OS in Python venv
   vars:
-    _pip_args: "{{ '--pre' if ovos_installer_channel == 'development' else '' }}"
     _ovos_release: "https://raw.githubusercontent.com/OpenVoiceOS/ovos-releases/refs/heads/main/constraints-{{ ovos_installer_channel }}.txt"
-    _pip_constraints: "{{ '--constraint ' + _ovos_release if ovos_installer_profile != 'satellite' else '' }}"
+    _pip_constraints: "--constraint {{ _ovos_release }}"
   moreati.uv.pip:
     requirements: "{{ item.file }}"
     virtualenv: "{{ ovos_installer_user_home }}/.venvs/ovos"
-    extra_args: "{{ _pip_args }} {{ _pip_constraints }}"
+    extra_args: "{{ _pip_constraints }}"
     state: latest
   register: _ovos_install_venv
   until: _ovos_install_venv is success

--- a/utils/scenario.sh
+++ b/utils/scenario.sh
@@ -68,6 +68,9 @@ if [ -f "$SCENARIO_PATH" ]; then
                     CHANNEL="testing"
                 elif [[ "${options[$option]}" == "alpha" ]]; then
                     CHANNEL="alpha"
+                elif [[ "${options[$option]}" == "development" ]]; then
+		    echo "development channel has been deprecated and will be removed in a furture release." >&2
+                    CHANNEL="testing"
                 else
                     export SCENARIO_NOT_SUPPORTED="true"
                     break

--- a/utils/scenario.sh
+++ b/utils/scenario.sh
@@ -68,9 +68,6 @@ if [ -f "$SCENARIO_PATH" ]; then
                     CHANNEL="testing"
                 elif [[ "${options[$option]}" == "alpha" ]]; then
                     CHANNEL="alpha"
-                elif [[ "${options[$option]}" == "development" ]]; then
-		    echo "development channel has been deprecated and will be removed in a furture release." >&2
-                    CHANNEL="testing"
                 else
                     export SCENARIO_NOT_SUPPORTED="true"
                     break


### PR DESCRIPTION
Although I am not clear why a satellite profile does not use a constraints file or definitions, this patch corrects the intent not to supply a constraint file for satellite installations.

This also re-enables the development channel, defaulting to `testing` with a deprecation warning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified installation logic for Python packages, ensuring consistent use of constraints across all profiles. The installation process no longer varies based on development or satellite profiles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->