### PR TITLE
[ansible/venv] Move internel skills and add home assistant skill

### DIFF
--- a/ansible/roles/ovos_installer/templates/virtualenv/extra-skills-requirements.txt.j2
+++ b/ansible/roles/ovos_installer/templates/virtualenv/extra-skills-requirements.txt.j2
@@ -1,5 +1,6 @@
-ovos-core[skills-internet,skills-media]
+ovos-core[skills-media]
 ovos-skill-icanhazdadjokes
+skill-homeassistant
 
 # No PyPi release
 git+https://github.com/OpenVoiceOS/skill-ovos-randomness.git

--- a/ansible/roles/ovos_installer/templates/virtualenv/skills-requirements.txt.j2
+++ b/ansible/roles/ovos_installer/templates/virtualenv/skills-requirements.txt.j2
@@ -1,10 +1,9 @@
-ovos-core[skills-essential]
+ovos-core[skills-essential,skills-internet]
 
 {% if ovos_installer_profile != "server" %}
 ovos-core[skills-audio]
 {% endif %}
 
-# No PyPi release
 {% if (ansible_architecture == "x86_64") or (ansible_architecture == "aarch64") or (ovos_installer_profile != "server") %}
 ovos-skill-ggwave
 {% endif %}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Internet skills are now included by default, enabling online functionality out of the box.
  * Added Home Assistant skill to the extra skills set for enhanced smart home control.
* **Chores**
  * Adjusted skill dependency groups to streamline default and extra installations.
  * Removed an obsolete comment from the skills requirements template.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->