### PR TITLE
[ansible/config] Bind websocket on 0.0.0.0 depending the method

### DIFF
--- a/ansible/roles/ovos_installer/templates/mycroft.conf.j2
+++ b/ansible/roles/ovos_installer/templates/mycroft.conf.j2
@@ -50,6 +50,7 @@
 {% endif %}
 {% endif %}
   "websocket": {
+    "host": {{ '0.0.0.0' if ovos_installer_method == "containers" else '127.0.0.1' }},
     "max_msg_size": {{ 100 if ovos_installer_feature_gui | bool and ovos_installer_method == "containers" else 25 }}
   },
   "PHAL": {
@@ -76,5 +77,5 @@
       "https://metrics.tigregotico.pt/intents"
     ]
   }
-{% endif %}  
+{% endif %}
 }


### PR DESCRIPTION
Fix issue discussed here https://github.com/orgs/OpenVoiceOS/discussions/302#discussioncomment-14203247

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * WebSocket host now auto-configures by deployment: container-based installs bind to 0.0.0.0 for external access, while non-container installs bind to 127.0.0.1 for local-only access. This updates network binding behavior to better match deployment environments.

* **Style**
  * Minor whitespace cleanup in configuration template; no functional impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->