### PR TITLE
[utils/common] Fix pgrep for detect_sound()

### DIFF
--- a/utils/common.sh
+++ b/utils/common.sh
@@ -113,7 +113,7 @@ function detect_user() {
 function detect_sound() {
     printf '%s' "➤ Detecting sound server... "
     local pulse_processes
-    pulse_processes="$(pgrep -a -f "pulse" | awk -F"/" '{ print $NF }' 2>>"$LOG_FILE")"
+    pulse_processes="$( (pgrep -a -f "pulse" 2>>"$LOG_FILE" || true) | awk -F"/" '{ print $NF }' )"
     if [[ "$pulse_processes" =~ "pulse" ]]; then
         # PULSE_SERVER is required by pactl as it is executed via sudo
         # Detect if a PulseAudio socket exists either Linux or WSL2
@@ -141,7 +141,7 @@ function detect_sound() {
             export SOUND_SERVER="N/A"
         fi
     # Looking for pipewire process
-    elif [ "$(pgrep -a -f "pipewire$" | awk -F"/" '{ print $NF }' 2>>"$LOG_FILE")" == "pipewire" ]; then
+    elif [ "$( (pgrep -a -f "pipewire$" 2>>"$LOG_FILE" || true) | awk -F"/" '{ print $NF }' )" == "pipewire" ]; then
         export SOUND_SERVER="PipeWire"
     else
         export SOUND_SERVER="N/A"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of detecting the active sound server (PulseAudio/PipeWire), preventing intermittent failures when the related processes aren’t running.
  * Eliminates premature script exits during detection, reducing false negatives and improving startup stability.
  * Ensures the correct sound server is selected consistently across environments, enhancing overall robustness without requiring any user configuration changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->