### PR TITLE
[utils/common] Add libhidapi-libusb0 for avrdude

### DIFF
--- a/utils/common.sh
+++ b/utils/common.sh
@@ -308,6 +308,7 @@ function required_packages() {
     if [ "${RASPBERRYPI_MODEL:-N/A}" != "N/A" ]; then
         extra_packages+=("i2c-tools")
         extra_packages+=("iw")
+        extra_packages+=("libhidapi-libusb0")
     fi
 
     case "${DISTRO_NAME}" in


### PR DESCRIPTION
Fixing the last piece of this issue: https://github.com/OpenVoiceOS/ovos-installer/issues/338

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Raspberry Pi hardware compatibility by ensuring required HID support is installed, reducing USB/HID connection issues and setup failures.

* **Chores**
  * Expanded Raspberry Pi dependency bundle to automatically include HID support, streamlining setup on compatible devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->