### PR TITLE
[tui] Add Fix jq parsing

### DIFF
--- a/tui/features.sh
+++ b/tui/features.sh
@@ -66,6 +66,12 @@ done
 
 if [ "$exit_status" -ne 1 ]; then
   jq -en '.features += $ARGS.positional' --args "${FEATURES_STATE[@]}" >"$TEMP_FEATURES_FILE"
+  if [ ! -f "$TEMP_PROFILE_FILE" ]; then
+    jq -n '{}' > "$TEMP_PROFILE_FILE"
+  fi
+  if [ ! -f "$TEMP_CHANNEL_FILE" ]; then
+    jq -n '{}' > "$TEMP_CHANNEL_FILE"
+  fi
   jq -es '.[0] * .[1] * . [2]' "$TEMP_PROFILE_FILE" "$TEMP_FEATURES_FILE" "$TEMP_CHANNEL_FILE" >"$INSTALLER_STATE_FILE"
   rm "$TEMP_FEATURES_FILE" "$TEMP_PROFILE_FILE" "$TEMP_CHANNEL_FILE"
 fi


### PR DESCRIPTION
```
➤ Looking for automated scenario... [done]
jq: error: Could not open file /tmp/profile.json: No such file or directory
jq: error: Could not open file /tmp/channel.json: No such file or directory
jq: error (at /tmp/channel.json:0): object ({"features"...) and null (null) cannot be multiplied
rm: cannot remove '/tmp/profile.json': No such file or directory
rm: cannot remove '/tmp/channel.json': No such file or directory
➤ Starting Ansible playbook... ☕🍵🧋
```