### PR TITLE
[mark2] Headers package name changed in Trixie.

### DIFF
--- a/ansible/roles/ovos_hardware_mark2/tasks/firmware.yml
+++ b/ansible/roles/ovos_hardware_mark2/tasks/firmware.yml
@@ -1,7 +1,7 @@
 ---
 - name: Install kernel headers
   ansible.builtin.apt:
-    name: raspberrypi-kernel-headers
+    name: "{{ ovos_hardware_mark2_kernel_headers_package }}"
     install_recommends: false
     update_cache: true
 

--- a/ansible/roles/ovos_hardware_mark2/vars/main.yml
+++ b/ansible/roles/ovos_hardware_mark2/vars/main.yml
@@ -1,2 +1,9 @@
 ---
 _ovos_hardware_mark2_vocalfusion_src_path: /usr/src/vocalfusion
+ovos_hardware_mark2_kernel_headers_package: >-
+  {{
+    'linux-headers-rpi-v8'
+    if ansible_distribution == 'Debian' and ansible_distribution_major_version == '13'
+    else
+    'raspberrypi-kernel-headers'
+  }}


### PR DESCRIPTION
Fix https://github.com/OpenVoiceOS/ovos-installer/issues/364

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated kernel headers package configuration to automatically support multiple Debian versions for improved system compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->