### PR TITLE
[utils/common] Exit if Python 3.14 is detected

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -39,6 +39,7 @@ detect_user
 delete_log
 detect_existing_instance
 get_os_information
+check_python_compatibility
 wsl2_requirements
 detect_cpu_instructions
 is_raspeberrypi_soc

--- a/utils/common.sh
+++ b/utils/common.sh
@@ -252,6 +252,27 @@ function get_os_information() {
     echo -e "[$done_format]"
 }
 
+# Validate the default Python version before creating the virtualenv.
+# onnxruntime is currently incompatible with Python 3.14, so abort early.
+function check_python_compatibility() {
+    printf '%s' "➤ Validating default Python version... "
+    local python_version="${PYTHON:-}"
+
+    if [ -z "$python_version" ]; then
+        echo -e "[$fail_format]"
+        echo "Unable to determine the default Python version." | tee -a "$LOG_FILE"
+        exit "${EXIT_MISSING_DEPENDENCY}"
+    fi
+
+    if [ "$python_version" == "3.14" ]; then
+        echo -e "[$fail_format]"
+        echo "Python $python_version is not supported because onnxruntime is not yet compatible with it." | tee -a "$LOG_FILE"
+        exit "${EXIT_MISSING_DEPENDENCY}"
+    fi
+
+    echo -e "[$done_format]"
+}
+
 # Install packages for Debian-based distributions
 function install_debian_packages() {
     local extra_packages=("$@")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added early Python compatibility validation to the installation process. The setup now verifies your Python environment before proceeding, providing clear error messages if the Python version is missing or unsupported to prevent setup failures later in the process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->