### PR TITLE
[setup] Fix Could not import the libdnf5

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -86,7 +86,18 @@ echo "➤ Starting Ansible playbook... ☕🍵🧋"
 
 # Execute the Ansible playbook on localhost
 export ANSIBLE_CONFIG=ansible/ansible.cfg
-export ANSIBLE_PYTHON_INTERPRETER="$VENV_PATH/bin/python3"
+case "${DISTRO_NAME:-}" in
+  fedora | almalinux | rocky | centos | rhel)
+    if [ -x /usr/libexec/platform-python ]; then
+      export ANSIBLE_PYTHON_INTERPRETER="/usr/libexec/platform-python"
+    else
+      export ANSIBLE_PYTHON_INTERPRETER="/usr/bin/python3"
+    fi
+    ;;
+  *)
+    export ANSIBLE_PYTHON_INTERPRETER="$VENV_PATH/bin/python3"
+    ;;
+esac
 export ANSIBLE_NOCOWS=1
 ansible-playbook -i 127.0.0.1, ansible/site.yml \
   -e "ovos_installer_user=${RUN_AS}" \


### PR DESCRIPTION
```
2026-01-04 18:24:33,603 p=4876 u=root n=ansible | TASK [ovos_installer : Install PipeWire with ALSA support] ************************************************************************************************************
2026-01-04 18:24:33,603 p=4876 u=root n=ansible | Sunday 04 January 2026  18:24:33 -0500 (0:00:00.062)       0:00:04.467 ******** 
2026-01-04 18:24:34,218 p=4876 u=root n=ansible | fatal: [127.0.0.1]: FAILED! => {"changed": false, "failures": [], "msg": "Could not import the libdnf5 python module using /home/costi/.venvs/ovos-installer/bin/python3 (3.12.12 (main, Oct 10 2025, 00:00:00) [GCC 15.2.1 20250924 (Red Hat 15.2.1-2)]). Please install python3-libdnf5 package or ensure you have specified the correct ansible_python_interpreter. (attempted ['/usr/libexec/platform-python', '/usr/bin/python3', '/usr/bin/python2', '/usr/bin/python'])"}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced setup process to intelligently select the appropriate Python interpreter for Ansible based on the detected Linux distribution. For Red Hat-based systems (Fedora, AlmaLinux, Rocky, CentOS, RHEL), the script now prefers the system Python interpreter when available, ensuring better compatibility. Other distributions continue using the virtual environment Python.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->