### PR TITLE
[tui] Make testing as the default channel

### DIFF
--- a/translations/en-us/strings.json
+++ b/translations/en-us/strings.json
@@ -7,7 +7,7 @@
   },
   "channels.sh": {
     "title": "Open Voice OS Installation - Channels",
-    "content": "Open Voice OS has three main release channels:\n\n  - stable (default)\n  - testing (pretty stable)\n  - alpha (bleeding edge)\n\nThe stable release of Open Voice OS is the recommended version for most users. It is well-tested and includes all the latest features and improvements that have been deemed stable.\n\nThe testing release of Open Voice OS is a more experimental version that includes new features and improvements that are still being tested. It is generally stable but may have some bugs or issues.\n\nThe alpha release of Open Voice OS is the most experimental version, containing the latest features and changes that are still in development. It may be unstable and is not recommended for everyday use.\n\nPlease select a channel:"
+    "content": "Open Voice OS has three main release channels:\n\n  - stable (stable but old)\n  - testing (default)\n  - alpha (bleeding edge)\n\nThe stable release of Open Voice OS is the recommended version for most users. It is well-tested and includes all the latest features and improvements that have been deemed stable.\n\nThe testing release of Open Voice OS is a more experimental version that includes new features and improvements that are still being tested. It is generally stable but may have some bugs or issues.\n\nThe alpha release of Open Voice OS is the most experimental version, containing the latest features and changes that are still in development. It may be unstable and is not recommended for everyday use.\n\nPlease select a channel:"
   },
   "detection.sh": {
     "title": "Open Voice OS Installation - Detected",

--- a/tui/channels.sh
+++ b/tui/channels.sh
@@ -3,7 +3,7 @@
 # shellcheck source=locales/en-us/channels.sh
 source "tui/locales/$LOCALE/channels.sh"
 
-active_channel="stable"
+active_channel="testing"
 available_channels=(stable testing alpha)
 
 # Handle existing installation

--- a/tui/locales/en-us/channels.sh
+++ b/tui/locales/en-us/channels.sh
@@ -3,8 +3,8 @@
 CONTENT="
 Open Voice OS has three main release channels:
 
-  - stable (default)
-  - testing (pretty stable)
+  - stable (stable but old)
+  - testing (default)
   - alpha (bleeding edge)
 
 The stable release of Open Voice OS is the recommended version for most users. It is well-tested and includes all the latest features and improvements that have been deemed stable.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release channel labels: the stable channel now displays as "stable but old," while the testing channel now displays as "default."
  * Changed the default selected release channel from stable to testing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->