### PR TITLE
[ansible] fix cgroup during uninstall

### DIFF
--- a/ansible/roles/ovos_containers/tasks/cgroup.yml
+++ b/ansible/roles/ovos_containers/tasks/cgroup.yml
@@ -20,7 +20,7 @@
     ovos_containers_cmdline_content: "{{ ovos_containers_cmdline_raw.content | b64decode | trim }}"
   when:
     - ovos_containers_enable_cgroup_memory | bool
-    - ovos_containers_cmdline_raw is defined
+    - ovos_containers_cmdline_stat.stat.exists | default(false) | bool
 
 - name: Compute missing cgroup parameters
   ansible.builtin.set_fact:

--- a/ansible/roles/ovos_containers/tasks/uninstall.yml
+++ b/ansible/roles/ovos_containers/tasks/uninstall.yml
@@ -106,7 +106,7 @@
     ovos_containers_cmdline_cleaned: "{{ _filtered_tokens | join(' ') }}"
   changed_when: false
   when:
-    - ovos_containers_cmdline_raw is defined
+    - ovos_containers_cmdline_stat.stat.exists | default(false) | bool
 
 - name: Assert cmdline will not be emptied by cgroup cleanup
   ansible.builtin.assert:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of container configuration file validation by refining how the system checks for file existence, ensuring correct behavior in edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->