### PR TITLE
[utils/common] Support Python 3.14 since ONNX does it

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ If you prefer to inspect before running, download the script first, review it, t
 
 This command downloads and runs the official installer script, which will guide you through the installation process interactively.
 
-> Heads-up: OVOS targets a supported Python runtime in its virtualenv (default `3.11`). The installer uses `uv` to provision that version if it is not already available. You can override with `OVOS_VENV_PYTHON`, but `3.14` is blocked because `onnxruntime` does not provide wheels for it.
+> Heads-up: OVOS targets a supported Python runtime in its virtualenv (default `3.11`). The installer uses `uv` to provision that version if it is not already available. You can override with `OVOS_VENV_PYTHON` if you want to use a different version that is available on your system.
 
 👉 [Start your Open Voice OS journey!](https://community.openconversational.ai/t/howto-begin-your-open-voice-os-journey-with-the-ovos-installer/14900)
 

--- a/tests/bats/python_compatibility.bats
+++ b/tests/bats/python_compatibility.bats
@@ -14,18 +14,16 @@ function setup() {
     assert_success
 }
 
-@test "function_check_python_compatibility_blocks_python_314_version" {
+@test "function_check_python_compatibility_allows_python_314_version" {
     OVOS_VENV_PYTHON="3.14"
     run check_python_compatibility
-    assert_failure
-    assert_equal "${status}" "${EXIT_MISSING_DEPENDENCY}"
+    assert_success
 }
 
-@test "function_check_python_compatibility_blocks_python_314_executable" {
+@test "function_check_python_compatibility_allows_python_314_executable" {
     OVOS_VENV_PYTHON="python3.14"
     run check_python_compatibility
-    assert_failure
-    assert_equal "${status}" "${EXIT_MISSING_DEPENDENCY}"
+    assert_success
 }
 
 function teardown() {

--- a/utils/common.sh
+++ b/utils/common.sh
@@ -354,7 +354,6 @@ function get_os_information() {
 }
 
 # Validate the requested Python version before creating the virtualenv.
-# onnxruntime is currently incompatible with Python 3.14, so abort early.
 function check_python_compatibility() {
     printf '%s' "➤ Validating Python version... "
     local python_version=""
@@ -388,12 +387,6 @@ function check_python_compatibility() {
         else
             echo "Unable to determine the default Python version." | tee -a "$LOG_FILE"
         fi
-        exit "${EXIT_MISSING_DEPENDENCY}"
-    fi
-
-    if [ -n "${OVOS_VENV_PYTHON:-}" ] && [ "$python_version" == "3.14" ]; then
-        echo -e "[$fail_format]"
-        echo "Python $python_version is not supported because onnxruntime is not yet compatible with it." | tee -a "$LOG_FILE"
         exit "${EXIT_MISSING_DEPENDENCY}"
     fi
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enabled Python 3.14 support. OVOS now allows using Python 3.14 while maintaining Python 3.11 as the default target runtime. Users can specify alternative Python versions through configuration to match their system setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->