### PR TITLE
[ansible/venv] workaround for setuptools

### DIFF
--- a/ansible/roles/ovos_installer/defaults/main.yml
+++ b/ansible/roles/ovos_installer/defaults/main.yml
@@ -66,6 +66,7 @@ ovos_installer_venv_python: "3.11"
 ovos_installer_enable_ggwave: "{{ (ovos_installer_channel | default('')) in ['stable', 'testing'] and ansible_facts.architecture in ['x86_64', 'aarch64'] }}"
 ovos_installer_uv_allow_prerelease: "{{ ansible_facts.python.version.major == 3 and (ansible_facts.python.version.minor | int) >= 13 }}"
 ovos_installer_tuning: false
+ovos_installer_setuptools_package: "setuptools<82"
 ovos_installer_tuning_performance: >-
   {{ ovos_installer_tuning | bool and (ovos_installer_raspberrypi | default('N/A')) != 'N/A' }}
 ovos_installer_tuning_audio_low_latency: "{{ ovos_installer_tuning_performance | bool }}"

--- a/ansible/roles/ovos_virtualenv/defaults/main.yml
+++ b/ansible/roles/ovos_virtualenv/defaults/main.yml
@@ -16,6 +16,7 @@ ovos_virtualenv_uv_allow_prerelease: >-
 ovos_virtualenv_uv_version: "{{ ovos_installer_uv_version | default('') }}"
 ovos_virtualenv_run_ovos_config: "{{ ovos_installer_run_ovos_config | default(false) }}"
 ovos_virtualenv_numpy_package: "{{ ovos_installer_numpy_package | default('numpy==1.26.4') }}"
+ovos_virtualenv_setuptools_package: "{{ ovos_installer_setuptools_package | default('setuptools<82') }}"
 ovos_virtualenv_messagebus_path: "{{ ovos_installer_user_home }}/.local/bin/ovos-messagebus"
 ovos_virtualenv_uninstall_extra_paths:
   - "{{ ovos_hardware_mark1_working_directory | default('/opt/mark1') }}"

--- a/ansible/roles/ovos_virtualenv/tasks/venv.yml
+++ b/ansible/roles/ovos_virtualenv/tasks/venv.yml
@@ -88,7 +88,10 @@
   become: true
   become_user: "{{ ovos_installer_user }}"
   ansible.builtin.command:
-    cmd: "{{ ovos_virtualenv_path }}/bin/python -m pip install -U pip setuptools wheel"
+    cmd: >-
+      {{ ovos_virtualenv_path }}/bin/python -m pip install -U
+      pip wheel
+      "{{ ovos_virtualenv_setuptools_package }}"
   environment:
     HOME: "{{ ovos_installer_user_home }}"
   changed_when: false
@@ -139,6 +142,12 @@
 - name: Ensure numpy Python library is installed
   moreati.uv.pip:
     name: "{{ ovos_virtualenv_numpy_package }}"
+    virtualenv: "{{ ovos_virtualenv_path }}"
+    state: present
+
+- name: Ensure setuptools Python library is compatible with OVOS runtime
+  moreati.uv.pip:
+    name: "{{ ovos_virtualenv_setuptools_package }}"
     virtualenv: "{{ ovos_virtualenv_path }}"
     state: present
 

--- a/tests/bats/code_quality.bats
+++ b/tests/bats/code_quality.bats
@@ -156,6 +156,22 @@ function setup() {
     unset apt_ensure
 }
 
+@test "virtualenv_pins_setuptools_for_pkg_resources" {
+    # setuptools>=82 dropped pkg_resources, which breaks ovos_plugin_manager imports.
+    run grep -q "ovos_installer_setuptools_package" ansible/roles/ovos_installer/defaults/main.yml
+    assert_success
+
+    run grep -q "ovos_virtualenv_setuptools_package" ansible/roles/ovos_virtualenv/defaults/main.yml
+    assert_success
+
+    # Guard against regression to an unpinned setuptools upgrade.
+    run grep -q "pip install -U pip setuptools wheel" ansible/roles/ovos_virtualenv/tasks/venv.yml
+    assert_failure
+
+    run grep -q "ovos_virtualenv_setuptools_package" ansible/roles/ovos_virtualenv/tasks/venv.yml
+    assert_success
+}
+
 function teardown() {
     rm -f "$LOG_FILE"
     if [ -n "$DETECT_SOUND_BACKUP" ]; then

--- a/tui/locales/en-us/finish.sh
+++ b/tui/locales/en-us/finish.sh
@@ -15,6 +15,8 @@ If you enabled the default skills feature then you can start to interact with yo
 The settings of your assistant could be changed in the $CONFIG_FILE configuration file.
 
 Should you need any assistance or updates in the future, feel free to reach out. Enjoy your Open Voice OS experience!
+
+Press OK to exit the installer.
 "
 TITLE="Open Voice OS Installation - Finish"
 


### PR DESCRIPTION
Fix:
- https://github.com/OpenVoiceOS/ovos-installer/issues/435
- https://github.com/OpenVoiceOS/ovos-installer/issues/432

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Implemented setuptools version constraints to ensure compatibility with OVOS runtime.

* **UI Improvements**
  * Updated installer completion message with exit confirmation prompt.

* **Tests**
  * Added validation tests to ensure setuptools compatibility constraints are enforced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->