### PR TITLE
[skills/ha] Fix config path n00b mistake...

### DIFF
--- a/ansible/roles/ovos_config/tasks/main.yml
+++ b/ansible/roles/ovos_config/tasks/main.yml
@@ -107,7 +107,7 @@
   block:
     - name: Ensure Home Assistant skill settings directory exists
       ansible.builtin.file:
-        path: "{{ ovos_installer_user_home }}/{{ ovos_config_mycroft_conf_relpath }}/skills/skill-homeassistant"
+        path: "{{ ovos_installer_user_home }}/{{ ovos_config_mycroft_conf_relpath }}/skills/{{ ovos_installer_homeassistant_skill_id }}"
         state: directory
         owner: "{{ ovos_installer_user }}"
         group: "{{ ovos_installer_group }}"
@@ -115,7 +115,7 @@
 
     - name: Write Home Assistant skill settings.json
       ansible.builtin.copy:
-        dest: "{{ ovos_installer_user_home }}/{{ ovos_config_mycroft_conf_relpath }}/skills/skill-homeassistant/settings.json"
+        dest: "{{ ovos_installer_user_home }}/{{ ovos_config_mycroft_conf_relpath }}/skills/{{ ovos_installer_homeassistant_skill_id }}/settings.json"
         owner: "{{ ovos_installer_user }}"
         group: "{{ ovos_installer_group }}"
         mode: "0600"

--- a/ansible/roles/ovos_installer/defaults/main.yml
+++ b/ansible/roles/ovos_installer/defaults/main.yml
@@ -113,6 +113,8 @@ ovos_installer_feature_skills: true
 ovos_installer_feature_extra_skills: false
 ovos_installer_feature_homeassistant: false
 ovos_installer_feature_gui: false
+# Home Assistant skill ID (directory name under `~/.config/mycroft/skills/` or `~/ovos/config/skills/`).
+ovos_installer_homeassistant_skill_id: "skill_homeassistant.oscillatelabsllc"
 ovos_installer_homeassistant_url: ""
 # Backward compatible alias; prefer ovos_installer_homeassistant_url.
 ovos_installer_homeassistant_host: ""

--- a/tui/homeassistant.sh
+++ b/tui/homeassistant.sh
@@ -61,9 +61,12 @@ fi
 # (useful when re-running the installer).
 ha_settings_file=""
 case "${METHOD:-virtualenv}" in
-  containers) ha_settings_file="${RUN_AS_HOME:-$HOME}/ovos/config/skills/skill-homeassistant/settings.json" ;;
-  virtualenv) ha_settings_file="${RUN_AS_HOME:-$HOME}/.config/mycroft/skills/skill-homeassistant/settings.json" ;;
-  *) ha_settings_file="${RUN_AS_HOME:-$HOME}/.config/mycroft/skills/skill-homeassistant/settings.json" ;;
+  containers)
+    ha_settings_file="${RUN_AS_HOME:-$HOME}/ovos/config/skills/skill_homeassistant.oscillatelabsllc/settings.json"
+    ;;
+  virtualenv | *)
+    ha_settings_file="${RUN_AS_HOME:-$HOME}/.config/mycroft/skills/skill_homeassistant.oscillatelabsllc/settings.json"
+    ;;
 esac
 
 ha_existing_url=""


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Home Assistant skill configuration updated to use a dynamic, configurable skill identifier instead of a hardcoded value.
  * Settings file paths now dynamically reference the new skill ID scheme for improved configuration flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->