### PR TITLE
[telemetry] Collect the information if HA is used or not

### DIFF
--- a/ansible/roles/ovos_telemetry/defaults/main.yml
+++ b/ansible/roles/ovos_telemetry/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 ovos_telemetry_feature_gui: "{{ ovos_installer_feature_gui | default(false) }}"
+ovos_telemetry_feature_homeassistant: "{{ ovos_installer_feature_homeassistant | default(false) }}"
 
 ovos_telemetry_geoip_url: http://ip-api.com/json
 ovos_telemetry_url: "https://telemetry.smartgic.io/ovos-installer/metrics/"

--- a/ansible/roles/ovos_telemetry/tasks/main.yml
+++ b/ansible/roles/ovos_telemetry/tasks/main.yml
@@ -54,7 +54,7 @@
                else (ovos_installer_raspberrypi | default('N/A')) }}
           skills_feature: "{{ ovos_installer_feature_skills | default(false) | bool }}"
           extra_skills_feature: "{{ ovos_installer_feature_extra_skills | default(false) | bool }}"
-          homeassistant_feature: "{{ ovos_installer_feature_homeassistant | default(false) | bool }}"
+          homeassistant_feature: "{{ ovos_telemetry_feature_homeassistant | default(false) | bool }}"
           gui_feature: "{{ ovos_telemetry_feature_gui | default(false) | bool }}"
           cpu_capable: "{{ ovos_installer_cpu_is_capable | default(false) | bool }}"
           tuning_enabled: "{{ (ovos_installer_tuning | default('no')) == 'yes' }}"

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -19,9 +19,9 @@ Below is a list of the collected data _(see the [Ansible task](https://github.co
 | `cpu_capable`          | Is the CPU supports AVX2 or SIMD instructions            |
 | `display_server`       | Is X or Wayland are used as display server               |
 | `extra_skills_feature` | Extra OVOS's skills enabled during the installation      |
-| `homeassistant_feature` | Home Assistant feature enabled during the installation     |
 | `gui_feature`          | GUI enabled during the installation                      |
 | `hardware`             | Is the device a Mark 1, Mark II or DevKit                |
+| `homeassistant_feature` | Home Assistant feature enabled during the installation    |
 | `installed_at`         | Date when OVOS has been installed                        |
 | `os_kernel`            | Kernel version of the host where OVOS is running         |
 | `os_name`              | OS name of the host where OVOS is running                |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Telemetry now records whether the Home Assistant feature is enabled; the flag defaults to disabled unless turned on.

* **Documentation**
  * Telemetry docs updated to show the new Home Assistant field and clarify that no Home Assistant URLs, API keys, or credentials are collected—only enabled/disabled status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->