### PR TITLE
[macos] Disable fake_barge_in on MacOS

### DIFF
--- a/ansible/roles/ovos_config/templates/mycroft.conf.j2
+++ b/ansible/roles/ovos_config/templates/mycroft.conf.j2
@@ -40,6 +40,7 @@
 {% endif %}
     }{% if _ovos_is_macos or _ovos_listener_has_wake_word %},{{ '\n' }}{% endif %}
 {% if _ovos_is_macos %}
+    "fake_barge_in": false,
     "microphone": {
       "module": "ovos-microphone-plugin-sounddevice"
     }{% if _ovos_listener_has_wake_word %},{{ '\n' }}{% endif %}

--- a/tests/bats/code_quality.bats
+++ b/tests/bats/code_quality.bats
@@ -198,6 +198,9 @@ function setup() {
     run grep -q "_ovos_listener_has_wake_word" ansible/roles/ovos_config/templates/mycroft.conf.j2
     assert_success
 
+    run grep -q "\"fake_barge_in\": false" ansible/roles/ovos_config/templates/mycroft.conf.j2
+    assert_success
+
     run grep -q "\"module\": \"ovos-microphone-plugin-sounddevice\"" ansible/roles/ovos_config/templates/mycroft.conf.j2
     assert_success
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "fake_barge_in" configuration option for macOS with default value of false.

* **Tests**
  * Enhanced test coverage to verify new macOS configuration option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->