### PR TITLE
[mark2] Force alpha channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,6 @@ The installer has been tested on the following Linux distributions and versions:
 
 Note: 'rolling' indicates a rolling release distribution with no fixed version number. Role metadata in `ansible/roles/*/meta/main.yml` lists the base OS families/versions (e.g., Debian/Ubuntu/EL/Fedora/Arch/Suse) that cover these distributions.
 
-Hardware requirement note: Mark II and DevKit installations require Debian Trixie (13). The installer exits if this requirement is not met when that hardware is detected.
-
 ## 🔄 Update
 
 To update, optionally back up your configuration (`~/.config/mycroft/mycroft.conf` or `~/ovos/config/mycroft.conf`) and re-run the installer. When prompted, answer **"No"** to _"Do you want to uninstall Open Voice OS?"_.

--- a/tests/bats/hardware_detection.bats
+++ b/tests/bats/hardware_detection.bats
@@ -102,6 +102,22 @@ function setup() {
     assert_success
 }
 
+@test "function_enforce_mark2_alpha_channel_forces_alpha" {
+    DETECTED_DEVICES=("tas5806")
+    CHANNEL="stable"
+
+    enforce_mark2_alpha_channel
+    assert_equal "$CHANNEL" "alpha"
+}
+
+@test "function_enforce_mark2_alpha_channel_does_not_force_devkit" {
+    DETECTED_DEVICES=("attiny1614" "tas5806")
+    CHANNEL="stable"
+
+    enforce_mark2_alpha_channel
+    assert_equal "$CHANNEL" "stable"
+}
+
 @test "function_enforce_mark2_devkit_trixie_requirement_rejects_non_trixie" {
     DETECTED_DEVICES=("tas5806")
     DISTRO_NAME="debian"

--- a/tests/bats/tui_lists.bats
+++ b/tests/bats/tui_lists.bats
@@ -118,6 +118,19 @@ function spy_value() {
     assert_equal "$(spy_value list_height)" "4"
 }
 
+@test "channels: hides non-alpha channels on Mark 2 hardware" {
+    EXISTING_INSTANCE="false"
+    DETECTED_DEVICES=("tas5806")
+    WHIPTAIL_FORCE_SELECTION="alpha"
+
+    # shellcheck source=tui/channels.sh
+    source tui/channels.sh
+
+    assert_equal "$(spy_value option_count)" "1"
+    assert_equal "$(spy_value list_height)" "4"
+    assert_equal "$(spy_value tags)" "alpha"
+}
+
 @test "profiles: shows all options when navigating back in a new install" {
     printf '%s\n' '{"profile":"ovos"}' >"$INSTALLER_STATE_FILE"
     EXISTING_INSTANCE="false"

--- a/tui/channels.sh
+++ b/tui/channels.sh
@@ -25,9 +25,27 @@ if [[ "${DISTRO_NAME:-}" == "macos" ]]; then
   available_channels=(alpha)
 fi
 
+# Mark 2 devices support only the alpha stream.
+mark2_detected="false"
+devkit_detected="false"
+for device in "${DETECTED_DEVICES[@]}"; do
+  case "$device" in
+    tas5806)
+      mark2_detected="true"
+      ;;
+    attiny1614)
+      devkit_detected="true"
+      ;;
+  esac
+done
+if [[ "$mark2_detected" == "true" && "$devkit_detected" != "true" ]]; then
+  active_channel="alpha"
+  available_channels=(alpha)
+fi
+
 list_height="${#available_channels[@]}"
 if [ "$list_height" -lt 1 ]; then
-  if [[ "${DISTRO_NAME:-}" == "macos" ]]; then
+  if [[ "${DISTRO_NAME:-}" == "macos" ]] || [[ "$mark2_detected" == "true" && "$devkit_detected" != "true" ]]; then
     available_channels=(alpha)
   else
     available_channels=(stable testing alpha)

--- a/utils/common.sh
+++ b/utils/common.sh
@@ -1105,7 +1105,34 @@ function i2c_scan() {
         echo -e "[$done_format]"
     fi
 
+    enforce_mark2_alpha_channel
     enforce_mark2_devkit_trixie_requirement
+}
+
+# Enforce alpha channel when Mark II hardware is detected.
+# Mark II detection requires tas5806 present and attiny1614 absent.
+function enforce_mark2_alpha_channel() {
+    local device
+    local mark2_detected="false"
+    local devkit_detected="false"
+
+    for device in "${DETECTED_DEVICES[@]}"; do
+        case "$device" in
+        tas5806)
+            mark2_detected="true"
+            ;;
+        attiny1614)
+            devkit_detected="true"
+            ;;
+        esac
+    done
+
+    if [[ "$mark2_detected" == "true" && "$devkit_detected" != "true" ]]; then
+        if [ "${CHANNEL:-}" != "alpha" ]; then
+            export CHANNEL="alpha"
+            echo "Mark II requires alpha channel. Forcing CHANNEL=alpha." | tee -a "$LOG_FILE"
+        fi
+    fi
 }
 
 # Enforce Debian Trixie (13) when Mark II/DevKit hardware is detected.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed hardware requirement note from README regarding Debian Trixie installation requirements.

* **New Features**
  * Mark 2 hardware now automatically forces and restricts channel selection to alpha when DevKit is not present.
  * Channel UI filters available channels appropriately for Mark 2 hardware configurations.

* **Tests**
  * Added test coverage for Mark 2 alpha channel enforcement logic.
  * Added test coverage for channel filtering on Mark 2 hardware.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->