### PR TITLE
[telemetry] Don't ask/push telemetry is instance already exist

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -122,6 +122,11 @@ else
   fi
 fi
 
+if [ "$EXISTING_INSTANCE" == "true" ]; then
+  export SHARE_TELEMETRY="false"
+  export SHARE_USAGE_TELEMETRY="false"
+fi
+
 echo "➤ Starting Ansible playbook... ☕🍵🧋"
 
 # Execute the Ansible playbook on localhost

--- a/tests/bats/code_quality.bats
+++ b/tests/bats/code_quality.bats
@@ -729,6 +729,38 @@ function setup() {
     assert_success
 }
 
+@test "existing_instance_skips_telemetry_prompts_in_tui" {
+    local file="tui/main.sh"
+
+    run grep -q '\[\[ "${EXISTING_INSTANCE:-false}" == "true" \]\]' "$file"
+    assert_success
+
+    run grep -q 'export SHARE_TELEMETRY="false"' "$file"
+    assert_success
+
+    run grep -q 'export SHARE_USAGE_TELEMETRY="false"' "$file"
+    assert_success
+
+    run grep -q "source tui/telemetry.sh" "$file"
+    assert_success
+
+    run grep -q "source tui/usage_telemetry.sh" "$file"
+    assert_success
+}
+
+@test "setup_forces_telemetry_off_for_existing_instance" {
+    local file="setup.sh"
+
+    run grep -q 'if \[ "\$EXISTING_INSTANCE" == "true" \]; then' "$file"
+    assert_success
+
+    run grep -q 'export SHARE_TELEMETRY="false"' "$file"
+    assert_success
+
+    run grep -q 'export SHARE_USAGE_TELEMETRY="false"' "$file"
+    assert_success
+}
+
 @test "telemetry_uses_existing_hardware_field_with_installer_fallback" {
     run grep -q "ovos_installer_hardware" ansible/roles/ovos_telemetry/tasks/main.yml
     assert_success

--- a/tui/main.sh
+++ b/tui/main.sh
@@ -40,8 +40,13 @@ fi
 # shellcheck source=tui/summary.sh
 source tui/summary.sh
 
-# shellcheck source=tui/telemetry.sh
-source tui/telemetry.sh
+if [[ "${EXISTING_INSTANCE:-false}" == "true" ]]; then
+    export SHARE_TELEMETRY="false"
+    export SHARE_USAGE_TELEMETRY="false"
+else
+    # shellcheck source=tui/telemetry.sh
+    source tui/telemetry.sh
 
-# shellcheck source=tui/usage_telemetry.sh
-source tui/usage_telemetry.sh
+    # shellcheck source=tui/usage_telemetry.sh
+    source tui/usage_telemetry.sh
+fi


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added tests to verify telemetry is disabled for existing instances and prompts are skipped accordingly.

* **Changes**
  * Telemetry and usage data sharing are now automatically disabled when running with an existing instance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->