### PR TITLE
Make sure /tmp got correct permissions

### DIFF
--- a/ansible/roles/ovos_hardware_mark2/tasks/firmware.yml
+++ b/ansible/roles/ovos_hardware_mark2/tasks/firmware.yml
@@ -1,4 +1,12 @@
 ---
+- name: Ensure /tmp permissions are apt-compatible
+  ansible.builtin.file:
+    path: /tmp
+    state: directory
+    owner: root
+    group: root
+    mode: "1777"
+
 - name: Install kernel headers
   ansible.builtin.apt:
     name: "{{ ovos_hardware_mark2_kernel_headers_package }}"

--- a/tests/bats/code_quality.bats
+++ b/tests/bats/code_quality.bats
@@ -665,6 +665,22 @@ function setup() {
     assert_success
 }
 
+@test "mark2_firmware_repairs_tmp_permissions_before_apt_update" {
+    local file="ansible/roles/ovos_hardware_mark2/tasks/firmware.yml"
+
+    run grep -q "Ensure /tmp permissions are apt-compatible" "$file"
+    assert_success
+
+    run bash -c "grep -A8 -F -- \"- name: Ensure /tmp permissions are apt-compatible\" \"$file\" | grep -q -- \"path: /tmp\""
+    assert_success
+
+    run bash -c "grep -A8 -F -- \"- name: Ensure /tmp permissions are apt-compatible\" \"$file\" | grep -q -- \"mode: \\\"1777\\\"\""
+    assert_success
+
+    run grep -q "Install kernel headers" "$file"
+    assert_success
+}
+
 @test "mark2_sj201_service_includes_sbin_in_runtime_path" {
     local defaults_file="ansible/roles/ovos_hardware_mark2/defaults/main.yml"
     local service_file="ansible/roles/ovos_hardware_mark2/templates/sj201.service.j2"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed temporary directory permissions configuration to ensure compatibility with package management operations during firmware installation. The directory is now properly initialized with correct ownership and access modes before kernel headers are installed.

* **Tests**
  * Added an automated test case to verify that temporary directory permissions are correctly configured as part of the firmware installation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->