### PR TITLE
[mark2] Fix hotword sensitivity

### DIFF
--- a/ansible/roles/ovos_config/defaults/main.yml
+++ b/ansible/roles/ovos_config/defaults/main.yml
@@ -1,6 +1,9 @@
 ---
 ovos_config_hotword_sensitivity: "{{ ovos_installer_hotword_sensitivity | default(0.95) }}"
 ovos_config_hotword_trigger_level: "{{ ovos_installer_hotword_trigger_level | default(1) }}"
+ovos_config_mark2_hotword_sensitivity: "{{ ovos_installer_mark2_hotword_sensitivity | default(0.55) }}"
+ovos_config_mark2_hotword_trigger_level: "{{ ovos_installer_mark2_hotword_trigger_level | default(3) }}"
+ovos_config_mark2_vad_pre_wake_enabled: "{{ ovos_installer_mark2_vad_pre_wake_enabled | default(false) }}"
 ovos_config_listener_multiplier: "{{ ovos_installer_listener_multiplier | default(1.5) }}"
 
 ovos_config_backup_paths_common:

--- a/ansible/roles/ovos_config/templates/mycroft.conf.j2
+++ b/ansible/roles/ovos_config/templates/mycroft.conf.j2
@@ -11,6 +11,8 @@
 {% set _ovos_is_mark2 = ('tas5806' in (ovos_installer_i2c_devices | default([]))) and ('attiny1614' not in (ovos_installer_i2c_devices | default([]))) %}
 {% set _ovos_use_sounddevice_mic = _ovos_is_macos or ('tas5806' in (ovos_installer_i2c_devices | default([]))) %}
 {% set _ovos_listener_has_wake_word = (_ovos_is_macos and ((ovos_installer_cpu_is_capable | default(false)) | bool)) or (ovos_installer_tuning | bool) %}
+{% set _ovos_hotword_sensitivity = ovos_config_mark2_hotword_sensitivity if _ovos_is_mark2 else ovos_config_hotword_sensitivity %}
+{% set _ovos_hotword_trigger_level = ovos_config_mark2_hotword_trigger_level if _ovos_is_mark2 else ovos_config_hotword_trigger_level %}
   "play_wav_cmdline": "{{ 'afplay %1' if ansible_facts.system == 'Darwin' else 'play %1' }}",
   "play_mp3_cmdline": "{{ 'afplay %1' if ansible_facts.system == 'Darwin' else 'play %1' }}",
   "lang": "{{ ovos_installer_locale }}",
@@ -57,17 +59,24 @@
 {% endif %}
 {% if _ovos_listener_has_wake_word %}
     "wake_word": "hey_mycroft",
+{% if _ovos_is_mark2 %}
+    "vad_pre_wake_enabled": {{ ovos_config_mark2_vad_pre_wake_enabled | bool | lower }},
+{% endif %}
     "multiplier": {{ ovos_config_listener_multiplier }}{% if ovos_installer_tuning | bool %},
-    "patience": 0.5{% endif %},
-    "hotwords": {
-      "hey_mycroft": {
-        "module": "ovos-ww-plugin-precise-onnx",
-        "sensitivity": {{ ovos_config_hotword_sensitivity }},
-        "trigger_level": {{ ovos_config_hotword_trigger_level }}
-      }
-    }
+    "patience": 0.5{% endif %}
 {% endif %}
   },
+{% if _ovos_listener_has_wake_word %}
+  "hotwords": {
+    "hey_mycroft": {
+      "module": "ovos-ww-plugin-precise-onnx",
+      "sensitivity": {{ _ovos_hotword_sensitivity }},
+      "trigger_level": {{ _ovos_hotword_trigger_level }},
+      "listen": true,
+      "active": true
+    }
+  },
+{% endif %}
 {% if ansible_facts.architecture in (ovos_installer_supported_desktop_architectures | default(['x86_64', 'aarch64', 'arm64'])) %}
   "skills": {
     "installer": {

--- a/ansible/roles/ovos_installer/defaults/main.yml
+++ b/ansible/roles/ovos_installer/defaults/main.yml
@@ -117,6 +117,9 @@ ovos_installer_venv_python_major: "{{ (ovos_installer_venv_python_parts | first 
 ovos_installer_venv_python_minor: "{{ (ovos_installer_venv_python_parts[1:] | first | default('0')) | int }}"
 ovos_installer_hotword_sensitivity: 0.95
 ovos_installer_hotword_trigger_level: 1
+ovos_installer_mark2_hotword_sensitivity: 0.55
+ovos_installer_mark2_hotword_trigger_level: 3
+ovos_installer_mark2_vad_pre_wake_enabled: false
 ovos_installer_listener_multiplier: 1.5
 ovos_installer_tuning_source_volume: 1.0
 ovos_installer_cpu_is_capable: false


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Mark2 devices can now customize hotword sensitivity (default: 0.55) and trigger level (default: 3) for optimized wake word detection performance
  * Added optional VAD pre-wake capability for Mark2 devices (disabled by default)

* **Chores**
  * Restructured hotword configuration architecture for improved organization
  * Added test coverage for hotword configuration defaults and structure validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->