### PR TITLE
[venv] Downgrade Padatious to 1.4.3

### DIFF
--- a/ansible/roles/ovos_config/templates/mycroft.conf.j2
+++ b/ansible/roles/ovos_config/templates/mycroft.conf.j2
@@ -132,6 +132,9 @@
         "mycroft.mic.unmute": 248
       }
     },
+    "ovos-PHAL-plugin-alsa": {
+      "enabled": false
+    },
     "ovos-phal-plugin-ipgeo": {
       "enabled": true
     }

--- a/ansible/roles/ovos_virtualenv/defaults/main.yml
+++ b/ansible/roles/ovos_virtualenv/defaults/main.yml
@@ -35,6 +35,7 @@ ovos_virtualenv_setuptools_package: "{{ ovos_installer_setuptools_package | defa
 ovos_virtualenv_mark2_skill_pins:
   - "{{ ovos_installer_mark2_datetime_package | default('ovos-skill-date-time==1.1.5') }}"
   - "{{ ovos_installer_mark2_weather_package | default('ovos-skill-weather==1.0.6') }}"
+ovos_virtualenv_mark2_padatious_package: "{{ ovos_installer_mark2_padatious_package | default('ovos-padatious==1.4.3') }}"
 ovos_virtualenv_padatious_cache_repo_url: https://github.com/OpenVoiceOS/padatious_cache
 ovos_virtualenv_padatious_cache_repo_version: dev
 ovos_virtualenv_padatious_cache_repo_path: "{{ ovos_virtualenv_tmp_dir }}/padatious_cache"

--- a/ansible/roles/ovos_virtualenv/tasks/venv.yml
+++ b/ansible/roles/ovos_virtualenv/tasks/venv.yml
@@ -266,6 +266,19 @@
     - not (ovos_installer_cleaning | default(false) | bool)
     - "'tas5806' in (ovos_installer_i2c_devices | default([]))"
 
+- name: Install stable padatious parser for Mark II
+  become: true
+  become_user: "{{ ovos_installer_user }}"
+  moreati.uv.pip:
+    name: "{{ ovos_virtualenv_mark2_padatious_package }}"
+    virtualenv: "{{ ovos_virtualenv_path }}"
+    extra_args: "--no-deps"
+    state: present
+  environment: "{{ ovos_virtualenv_uv_environment }}"
+  when:
+    - not (ovos_installer_cleaning | default(false) | bool)
+    - "'tas5806' in (ovos_installer_i2c_devices | default([]))"
+
 - name: Checkout padatious cache repository
   ansible.builtin.git:
     repo: "{{ ovos_virtualenv_padatious_cache_repo_url }}"

--- a/tests/bats/code_quality.bats
+++ b/tests/bats/code_quality.bats
@@ -337,6 +337,12 @@ function setup() {
     run bash -c "grep -A4 -F -- \"\\\"ovos-phal-plugin-ipgeo\\\": {\" \"$mark2_scoped_file\" | grep -q -- \"\\\"enabled\\\": true\""
     assert_success
 
+    run grep -F -q "\"ovos-PHAL-plugin-alsa\": {" "$mark2_scoped_file"
+    assert_success
+
+    run bash -c "grep -A4 -F -- \"\\\"ovos-PHAL-plugin-alsa\\\": {\" \"$mark2_scoped_file\" | grep -q -- \"\\\"enabled\\\": false\""
+    assert_success
+
     rm -f "$mark2_scoped_file"
 }
 
@@ -756,6 +762,29 @@ function setup() {
 
     run grep -F -q "ovos_virtualenv_mark2_weather_package:" "$defaults_file"
     assert_failure
+}
+
+@test "virtualenv_mark2_pins_stable_padatious_parser" {
+    local defaults_file="ansible/roles/ovos_virtualenv/defaults/main.yml"
+    local tasks_file="ansible/roles/ovos_virtualenv/tasks/venv.yml"
+
+    run grep -F -q "ovos_virtualenv_mark2_padatious_package:" "$defaults_file"
+    assert_success
+
+    run grep -F -q "ovos-padatious==1.4.3" "$defaults_file"
+    assert_success
+
+    run grep -F -q "Install stable padatious parser for Mark II" "$tasks_file"
+    assert_success
+
+    run bash -c "grep -A12 -F -- \"Install stable padatious parser for Mark II\" \"$tasks_file\" | grep -F -q -- \"name: \\\"{{ ovos_virtualenv_mark2_padatious_package }}\\\"\""
+    assert_success
+
+    run bash -c "grep -A12 -F -- \"Install stable padatious parser for Mark II\" \"$tasks_file\" | grep -F -q -- \"extra_args: \\\"--no-deps\\\"\""
+    assert_success
+
+    run bash -c "grep -A12 -F -- \"Install stable padatious parser for Mark II\" \"$tasks_file\" | grep -F -q -- \"'tas5806' in (ovos_installer_i2c_devices | default([]))\""
+    assert_success
 }
 
 @test "virtualenv_installs_padatious_cache_for_all_virtualenv_installs" {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ALSA audio plugin configuration support for Mark II devices, disabled by default
  * Pinned padatious parser to a stable version for Mark II to ensure consistent performance

* **Tests**
  * Added automated test coverage for ALSA plugin configuration and padatious parser version settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->