### PR TITLE
[venv] Remove weather, datetime and padatious pinning

### DIFF
--- a/ansible/roles/ovos_virtualenv/defaults/main.yml
+++ b/ansible/roles/ovos_virtualenv/defaults/main.yml
@@ -32,10 +32,6 @@ ovos_virtualenv_shell_init_file: "{{ ovos_installer_user_home }}/{{ '.zshrc' if 
 ovos_virtualenv_run_ovos_config: "{{ ovos_installer_run_ovos_config | default(false) }}"
 ovos_virtualenv_numpy_package: "{{ ovos_installer_numpy_package | default('numpy==1.26.4') }}"
 ovos_virtualenv_setuptools_package: "{{ ovos_installer_setuptools_package | default('setuptools<82') }}"
-ovos_virtualenv_mark2_skill_pins:
-  - "{{ ovos_installer_mark2_datetime_package | default('ovos-skill-date-time==1.1.5') }}"
-  - "{{ ovos_installer_mark2_weather_package | default('ovos-skill-weather==1.0.6') }}"
-ovos_virtualenv_mark2_padatious_package: "{{ ovos_installer_mark2_padatious_package | default('ovos-padatious==1.4.3') }}"
 ovos_virtualenv_padatious_cache_repo_url: https://github.com/OpenVoiceOS/padatious_cache
 ovos_virtualenv_padatious_cache_repo_version: dev
 ovos_virtualenv_padatious_cache_repo_path: "{{ ovos_virtualenv_tmp_dir }}/padatious_cache"

--- a/ansible/roles/ovos_virtualenv/tasks/venv.yml
+++ b/ansible/roles/ovos_virtualenv/tasks/venv.yml
@@ -250,35 +250,6 @@
     label: "{{ item.file }}"
   when: item.state | bool
 
-- name: Install stable skill pins for Mark II
-  become: true
-  become_user: "{{ ovos_installer_user }}"
-  moreati.uv.pip:
-    name: "{{ item }}"
-    virtualenv: "{{ ovos_virtualenv_path }}"
-    extra_args: "--no-deps"
-    state: present
-  environment: "{{ ovos_virtualenv_uv_environment }}"
-  loop: "{{ ovos_virtualenv_mark2_skill_pins }}"
-  loop_control:
-    label: "{{ item }}"
-  when:
-    - not (ovos_installer_cleaning | default(false) | bool)
-    - "'tas5806' in (ovos_installer_i2c_devices | default([]))"
-
-- name: Install stable padatious parser for Mark II
-  become: true
-  become_user: "{{ ovos_installer_user }}"
-  moreati.uv.pip:
-    name: "{{ ovos_virtualenv_mark2_padatious_package }}"
-    virtualenv: "{{ ovos_virtualenv_path }}"
-    extra_args: "--no-deps"
-    state: present
-  environment: "{{ ovos_virtualenv_uv_environment }}"
-  when:
-    - not (ovos_installer_cleaning | default(false) | bool)
-    - "'tas5806' in (ovos_installer_i2c_devices | default([]))"
-
 - name: Checkout padatious cache repository
   ansible.builtin.git:
     repo: "{{ ovos_virtualenv_padatious_cache_repo_url }}"

--- a/tests/bats/code_quality.bats
+++ b/tests/bats/code_quality.bats
@@ -720,33 +720,21 @@ function setup() {
     assert_success
 }
 
-@test "virtualenv_mark2_pins_stable_skills_without_dependency_resolution" {
+@test "virtualenv_mark2_does_not_pin_datetime_or_weather_skills" {
     local defaults_file="ansible/roles/ovos_virtualenv/defaults/main.yml"
     local tasks_file="ansible/roles/ovos_virtualenv/tasks/venv.yml"
 
     run grep -F -q "ovos_virtualenv_mark2_skill_pins:" "$defaults_file"
-    assert_success
+    assert_failure
 
     run grep -F -q "ovos-skill-date-time==1.1.5" "$defaults_file"
-    assert_success
+    assert_failure
 
     run grep -F -q "ovos-skill-weather==1.0.6" "$defaults_file"
-    assert_success
+    assert_failure
 
     run grep -F -q "Install stable skill pins for Mark II" "$tasks_file"
-    assert_success
-
-    run bash -c "grep -A14 -F -- \"Install stable skill pins for Mark II\" \"$tasks_file\" | grep -F -q -- \"loop: \\\"{{ ovos_virtualenv_mark2_skill_pins }}\\\"\""
-    assert_success
-
-    run bash -c "grep -A14 -F -- \"Install stable skill pins for Mark II\" \"$tasks_file\" | grep -F -q -- \"name: \\\"{{ item }}\\\"\""
-    assert_success
-
-    run bash -c "grep -A14 -F -- \"Install stable skill pins for Mark II\" \"$tasks_file\" | grep -F -q -- \"extra_args: \\\"--no-deps\\\"\""
-    assert_success
-
-    run bash -c "grep -A14 -F -- \"Install stable skill pins for Mark II\" \"$tasks_file\" | grep -F -q -- \"'tas5806' in (ovos_installer_i2c_devices | default([]))\""
-    assert_success
+    assert_failure
 
     run grep -F -q "Install known-good date-time skill for Mark II" "$tasks_file"
     assert_failure
@@ -761,27 +749,18 @@ function setup() {
     assert_failure
 }
 
-@test "virtualenv_mark2_pins_stable_padatious_parser" {
+@test "virtualenv_mark2_does_not_pin_padatious_parser" {
     local defaults_file="ansible/roles/ovos_virtualenv/defaults/main.yml"
     local tasks_file="ansible/roles/ovos_virtualenv/tasks/venv.yml"
 
     run grep -F -q "ovos_virtualenv_mark2_padatious_package:" "$defaults_file"
-    assert_success
+    assert_failure
 
     run grep -F -q "ovos-padatious==1.4.3" "$defaults_file"
-    assert_success
+    assert_failure
 
     run grep -F -q "Install stable padatious parser for Mark II" "$tasks_file"
-    assert_success
-
-    run bash -c "grep -A12 -F -- \"Install stable padatious parser for Mark II\" \"$tasks_file\" | grep -F -q -- \"name: \\\"{{ ovos_virtualenv_mark2_padatious_package }}\\\"\""
-    assert_success
-
-    run bash -c "grep -A12 -F -- \"Install stable padatious parser for Mark II\" \"$tasks_file\" | grep -F -q -- \"extra_args: \\\"--no-deps\\\"\""
-    assert_success
-
-    run bash -c "grep -A12 -F -- \"Install stable padatious parser for Mark II\" \"$tasks_file\" | grep -F -q -- \"'tas5806' in (ovos_installer_i2c_devices | default([]))\""
-    assert_success
+    assert_failure
 }
 
 @test "virtualenv_installs_padatious_cache_for_all_virtualenv_installs" {

--- a/tests/bats/hardware_detection.bats
+++ b/tests/bats/hardware_detection.bats
@@ -110,6 +110,15 @@ function setup() {
     assert_equal "$CHANNEL" "alpha"
 }
 
+@test "function_enforce_mark2_alpha_channel_is_silent" {
+    DETECTED_DEVICES=("tas5806")
+    CHANNEL="stable"
+
+    run enforce_mark2_alpha_channel
+    assert_success
+    assert_output ""
+}
+
 @test "function_enforce_mark2_alpha_channel_does_not_force_devkit" {
     DETECTED_DEVICES=("attiny1614" "tas5806")
     CHANNEL="stable"
@@ -180,6 +189,15 @@ function setup() {
 
     enforce_mark2_devkit_display_server
     assert_equal "$DISPLAY_SERVER" "eglfs"
+}
+
+@test "function_enforce_mark2_devkit_display_server_is_silent" {
+    DETECTED_DEVICES=("tas5806")
+    DISPLAY_SERVER="N/A"
+
+    run enforce_mark2_devkit_display_server
+    assert_success
+    assert_output ""
 }
 
 @test "function_enforce_mark2_devkit_display_server_keeps_detected_compositor" {

--- a/utils/common.sh
+++ b/utils/common.sh
@@ -1132,7 +1132,7 @@ function enforce_mark2_alpha_channel() {
     if [[ "$mark2_detected" == "true" && "$devkit_detected" != "true" ]]; then
         if [ "${CHANNEL:-}" != "alpha" ]; then
             export CHANNEL="alpha"
-            echo "Mark II requires alpha channel. Forcing CHANNEL=alpha." | tee -a "$LOG_FILE"
+            printf '%s\n' "Mark II requires alpha channel. Forcing CHANNEL=alpha." >>"$LOG_FILE"
         fi
     fi
 }
@@ -1198,7 +1198,7 @@ function enforce_mark2_devkit_display_server() {
 
     if [ "${DISPLAY_SERVER:-N/A}" == "N/A" ]; then
         export DISPLAY_SERVER="eglfs"
-        echo "Mark II/DevKit headless display detected. Setting DISPLAY_SERVER=eglfs." | tee -a "$LOG_FILE"
+        printf '%s\n' "Mark II/DevKit headless display detected. Setting DISPLAY_SERVER=eglfs." >>"$LOG_FILE"
     fi
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Removed version pinning for Mark II devices' date-time and weather skills, as well as the padatious parser. The system will now use default package versions for these components instead of specific pinned versions.

* **Tests**
  * Updated existing tests to reflect removal of skill and padatious pinning.
  * Added new hardware detection tests for Mark II alpha channel and display server validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->