### PR TITLE
Enforce alpha-only channel and virtualenv gating for Mark II/DevKit

### DIFF
--- a/tests/bats/hardware_detection.bats
+++ b/tests/bats/hardware_detection.bats
@@ -168,12 +168,12 @@ EOF
     assert_output ""
 }
 
-@test "function_enforce_mark2_alpha_channel_does_not_force_devkit" {
+@test "function_enforce_mark2_alpha_channel_forces_alpha_on_devkit" {
     DETECTED_DEVICES=("attiny1614" "tas5806")
     CHANNEL="testing"
 
     enforce_mark2_alpha_channel
-    assert_equal "$CHANNEL" "testing"
+    assert_equal "$CHANNEL" "alpha"
 }
 
 @test "function_enforce_mark2_devkit_gui_support_does_not_force_feature_gui_on_trixie" {

--- a/tests/bats/tui_lists.bats
+++ b/tests/bats/tui_lists.bats
@@ -121,7 +121,7 @@ function spy_value() {
     assert_equal "$(spy_value list_height)" "4"
 }
 
-@test "channels: hides non-alpha channels on Mark 2 hardware" {
+@test "channels: hides non-alpha channels on Mark 2/DevKit hardware" {
     EXISTING_INSTANCE="false"
     DETECTED_DEVICES=("tas5806")
     WHIPTAIL_FORCE_SELECTION="alpha"
@@ -227,17 +227,18 @@ function spy_value() {
     assert_equal "$(spy_value tags)" "virtualenv"
 }
 
-@test "methods: does not apply Mark 2 restriction to DevKit detection" {
+@test "methods: applies Mark 2 restriction to DevKit detection" {
     EXISTING_INSTANCE="false"
     INSTANCE_TYPE=""
     DETECTED_DEVICES=("attiny1614" "tas5806")
-    WHIPTAIL_FORCE_SELECTION="containers"
+    WHIPTAIL_FORCE_SELECTION="virtualenv"
 
     # shellcheck source=tui/methods.sh
     source tui/methods.sh
 
-    assert_equal "$(spy_value option_count)" "2"
+    assert_equal "$(spy_value option_count)" "1"
     assert_equal "$(spy_value list_height)" "4"
+    assert_equal "$(spy_value tags)" "virtualenv"
 }
 
 @test "features: checklist always has non-zero list-height and options" {

--- a/tui/channels.sh
+++ b/tui/channels.sh
@@ -25,27 +25,23 @@ if [[ "${DISTRO_NAME:-}" == "macos" ]]; then
   available_channels=(alpha)
 fi
 
-# Mark 2 devices support only the alpha stream.
-mark2_detected="false"
-devkit_detected="false"
+# Mark 2/DevKit devices support only the alpha stream.
+mark2_or_devkit_detected="false"
 for device in "${DETECTED_DEVICES[@]}"; do
   case "$device" in
     tas5806)
-      mark2_detected="true"
-      ;;
-    attiny1614)
-      devkit_detected="true"
+      mark2_or_devkit_detected="true"
       ;;
   esac
 done
-if [[ "$mark2_detected" == "true" && "$devkit_detected" != "true" ]]; then
+if [[ "$mark2_or_devkit_detected" == "true" ]]; then
   active_channel="alpha"
   available_channels=(alpha)
 fi
 
 list_height="${#available_channels[@]}"
 if [ "$list_height" -lt 1 ]; then
-  if [[ "${DISTRO_NAME:-}" == "macos" ]] || [[ "$mark2_detected" == "true" && "$devkit_detected" != "true" ]]; then
+  if [[ "${DISTRO_NAME:-}" == "macos" ]] || [[ "$mark2_or_devkit_detected" == "true" ]]; then
     available_channels=(alpha)
   else
     available_channels=(testing alpha)

--- a/tui/methods.sh
+++ b/tui/methods.sh
@@ -39,20 +39,16 @@ if [ "$EXISTING_INSTANCE" == "true" ]; then
   esac
 fi
 
-# Mark 2 devices only support virtualenv installs.
-mark2_detected="false"
-devkit_detected="false"
+# Mark 2/DevKit devices only support virtualenv installs.
+mark2_or_devkit_detected="false"
 for device in "${DETECTED_DEVICES[@]}"; do
   case "$device" in
     tas5806)
-      mark2_detected="true"
-      ;;
-    attiny1614)
-      devkit_detected="true"
+      mark2_or_devkit_detected="true"
       ;;
   esac
 done
-if [[ "$mark2_detected" == "true" && "$devkit_detected" != "true" ]]; then
+if [[ "$mark2_or_devkit_detected" == "true" ]]; then
   active_method="virtualenv"
   available_methods=(virtualenv)
 fi

--- a/utils/common.sh
+++ b/utils/common.sh
@@ -1501,16 +1501,15 @@ function is_debian_trixie() {
     }
 }
 
-# Enforce alpha channel when Mark II hardware is detected.
-# Mark II detection requires tas5806 present and attiny1614 absent.
+# Enforce alpha channel when Mark II/DevKit hardware is detected.
 function enforce_mark2_alpha_channel() {
-    if ! is_mark2_detected; then
+    if ! is_mark2_or_devkit_detected; then
         return 0
     fi
 
     if [ "${CHANNEL:-}" != "alpha" ]; then
         export CHANNEL="alpha"
-        printf '%s\n' "Mark II requires alpha channel. Forcing CHANNEL=alpha." >>"$LOG_FILE"
+        printf '%s\n' "Mark II/DevKit requires alpha channel. Forcing CHANNEL=alpha." >>"$LOG_FILE"
     fi
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated hardware detection tests to reflect Mark II/DevKit device handling scenarios.

* **Chores**
  * Consolidated device detection logic for Mark II and DevKit hardware into unified handling.
  * Updated system messages for alpha channel requirement on Mark II/DevKit devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->