### PR TITLE
Fix systemd uninstall drop-in paths

### DIFF
--- a/ansible/roles/ovos_services/tasks/uninstall.yml
+++ b/ansible/roles/ovos_services/tasks/uninstall.yml
@@ -35,7 +35,7 @@
 
 - name: Remove OVOS system drop-in directories
   ansible.builtin.file:
-    path: "{{ ovos_installer_systemd_system_path }}/{{ item }}.service.d"
+    path: "{{ ovos_installer_systemd_system_path }}/{{ item }}.d"
     state: absent
   loop: "{{ ovos_services_uninstall_units }}"
   notify: Reload Systemd
@@ -44,7 +44,7 @@
   become: true
   become_user: "{{ ovos_installer_user }}"
   ansible.builtin.file:
-    path: "{{ ovos_installer_systemd_user_path }}/{{ item }}.service.d"
+    path: "{{ ovos_installer_systemd_user_path }}/{{ item }}.d"
     state: absent
   loop: "{{ ovos_services_uninstall_units }}"
   notify: Reload Systemd User

--- a/tests/bats/code_quality.bats
+++ b/tests/bats/code_quality.bats
@@ -1794,6 +1794,19 @@ function setup() {
     assert_success
 }
 
+@test "services_uninstall_uses_correct_dropin_directory_paths" {
+    local file="ansible/roles/ovos_services/tasks/uninstall.yml"
+
+    run grep -F -q 'path: "{{ ovos_installer_systemd_system_path }}/{{ item }}.d"' "$file"
+    assert_success
+
+    run grep -F -q 'path: "{{ ovos_installer_systemd_user_path }}/{{ item }}.d"' "$file"
+    assert_success
+
+    run grep -q '\.service\.d' "$file"
+    assert_failure
+}
+
 @test "install_ansible_installs_collections_to_repo_local_path" {
     run grep -F -q 'collections_path="${PWD}/.ansible/collections"' utils/common.sh
     assert_success


### PR DESCRIPTION
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the uninstall process to remove drop-in directories from the proper system-wide and user-specific paths.

* **Tests**
  * Added test coverage to validate that uninstall uses the correct drop-in directory paths and excludes outdated patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->