### PR TITLE
Clear stale cached I2C state

### DIFF
--- a/tests/bats/hardware_detection.bats
+++ b/tests/bats/hardware_detection.bats
@@ -94,6 +94,7 @@ function setup() {
     CHANNEL="testing"
     PROFILE="ovos"
     FEATURE_GUI="false"
+    EXISTING_INSTANCE="true"
     RUN_AS_HOME="$(mktemp -d /tmp/ovos-installer-bats.XXXXXX)"
     mkdir -p "$RUN_AS_HOME/.local/state/ovos"
     cat >"$RUN_AS_HOME/.local/state/ovos/installer.json" <<'EOF'
@@ -122,6 +123,48 @@ EOF
     assert_equal "$?" "0"
     assert_equal "$DISPLAY_SERVER" "eglfs"
     assert_equal "$CHANNEL" "alpha"
+
+    rm -rf "$RUN_AS_HOME"
+}
+
+@test "function_i2c_scan_does_not_restore_cached_mark2_state_on_new_install" {
+    RASPBERRYPI_MODEL="Raspberry Pi 4"
+    DISTRO_NAME="debian"
+    DISTRO_VERSION_ID="13"
+    DISTRO_VERSION="Debian GNU/Linux 13 (trixie)"
+    DISPLAY_SERVER="N/A"
+    CHANNEL="testing"
+    PROFILE="ovos"
+    FEATURE_GUI="false"
+    EXISTING_INSTANCE="false"
+    RUN_AS_HOME="$(mktemp -d /tmp/ovos-installer-bats.XXXXXX)"
+    mkdir -p "$RUN_AS_HOME/.local/state/ovos"
+    cat >"$RUN_AS_HOME/.local/state/ovos/installer.json" <<'EOF'
+{"i2c_devices":["tas5806"]}
+EOF
+    DETECTED_DEVICES=()
+
+    function dtparam() {
+        return 0
+    }
+    function lsmod() {
+        return 0
+    }
+    function modprobe() {
+        return 0
+    }
+    function i2c_get() {
+        return 1
+    }
+    export -f dtparam lsmod modprobe i2c_get
+
+    i2c_scan
+    assert_equal "$?" "0"
+
+    run has_detected_device "tas5806"
+    assert_failure
+    assert_equal "$DISPLAY_SERVER" "N/A"
+    assert_equal "$CHANNEL" "testing"
 
     rm -rf "$RUN_AS_HOME"
 }
@@ -320,6 +363,25 @@ EOF
     assert_equal "$?" "0"
 
     run jq -e '(.i2c_devices | sort) == ["attiny1614","tas5806"]' "$RUN_AS_HOME/.local/state/ovos/installer.json"
+    assert_success
+
+    rm -rf "$RUN_AS_HOME"
+}
+
+@test "function_state_directory_clears_persisted_i2c_devices_when_none_are_detected" {
+    RUN_AS_HOME="$(mktemp -d /tmp/ovos-installer-bats.XXXXXX)"
+    RUN_AS="$(id -un)"
+    RUN_AS_GROUP="$(id -gn)"
+    mkdir -p "$RUN_AS_HOME/.local/state/ovos"
+    cat >"$RUN_AS_HOME/.local/state/ovos/installer.json" <<'EOF'
+{"i2c_devices":["tas5806"]}
+EOF
+    DETECTED_DEVICES=()
+
+    state_directory
+    assert_equal "$?" "0"
+
+    run jq -e '.i2c_devices == []' "$RUN_AS_HOME/.local/state/ovos/installer.json"
     assert_success
 
     rm -rf "$RUN_AS_HOME"

--- a/utils/common.sh
+++ b/utils/common.sh
@@ -1414,10 +1414,11 @@ function i2c_scan() {
             fi
         done
 
-        # If the live scan does not detect any supported devices (which can
-        # happen transiently on re-runs), recover the last known I2C device
-        # list from installer state to keep Mark II/DevKit gating deterministic.
-        if ! has_detected_device "atmega328p" && \
+        # If the live scan does not detect any supported devices during an
+        # existing-install rerun, recover the last known I2C device list from
+        # installer state to keep Mark II/DevKit gating deterministic.
+        if [ "${EXISTING_INSTANCE:-false}" == "true" ] && \
+            ! has_detected_device "atmega328p" && \
             ! has_detected_device "attiny1614" && \
             ! has_detected_device "tas5806"; then
             restore_detected_devices_from_state || true
@@ -1733,19 +1734,17 @@ function state_directory() {
             i2c_devices_json="$(jq -c -n '$ARGS.positional' --args "${detected_devices_to_store[@]}" 2>>"$LOG_FILE" || echo "[]")"
         fi
 
-        if [ "$i2c_devices_json" != "[]" ]; then
-            if state_tmp="$(mktemp "${TMPDIR:-/tmp}/ovos-installer-state.XXXXXX" 2>>"$LOG_FILE")"; then
-                if [ -f "$INSTALLER_STATE_FILE" ] && \
-                    jq --argjson i2c_devices "$i2c_devices_json" \
-                        'if type=="object" then . else {} end | .i2c_devices = $i2c_devices' \
-                        "$INSTALLER_STATE_FILE" >"$state_tmp" 2>>"$LOG_FILE"; then
-                    mv -f "$state_tmp" "$INSTALLER_STATE_FILE"
-                elif jq -n --argjson i2c_devices "$i2c_devices_json" \
-                    '{i2c_devices: $i2c_devices}' >"$state_tmp" 2>>"$LOG_FILE"; then
-                    mv -f "$state_tmp" "$INSTALLER_STATE_FILE"
-                else
-                    rm -f "$state_tmp"
-                fi
+        if state_tmp="$(mktemp "${TMPDIR:-/tmp}/ovos-installer-state.XXXXXX" 2>>"$LOG_FILE")"; then
+            if [ -f "$INSTALLER_STATE_FILE" ] && \
+                jq --argjson i2c_devices "$i2c_devices_json" \
+                    'if type=="object" then . else {} end | .i2c_devices = $i2c_devices' \
+                    "$INSTALLER_STATE_FILE" >"$state_tmp" 2>>"$LOG_FILE"; then
+                mv -f "$state_tmp" "$INSTALLER_STATE_FILE"
+            elif jq -n --argjson i2c_devices "$i2c_devices_json" \
+                '{i2c_devices: $i2c_devices}' >"$state_tmp" 2>>"$LOG_FILE"; then
+                mv -f "$state_tmp" "$INSTALLER_STATE_FILE"
+            else
+                rm -f "$state_tmp"
             fi
         fi
     fi


### PR DESCRIPTION
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined I2C hardware detection to properly distinguish between new and existing system installations when determining whether to restore cached device information during detection scans.
  * Improved state persistence logic to consistently record all device detection results in the system state file, ensuring accurate tracking even when no devices are found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->