### PR TITLE
Scope sound detection to installer user

### DIFF
--- a/tests/bats/code_quality.bats
+++ b/tests/bats/code_quality.bats
@@ -59,6 +59,9 @@ function setup() {
 
     run grep -q "shutil.which(\"pgrep\")" utils/detect_sound.py
     assert_success
+
+    run grep -F -q 'command.extend(["-u", username])' utils/detect_sound.py
+    assert_success
 }
 
 @test "printf_migration_required_packages" {

--- a/tests/bats/sound.bats
+++ b/tests/bats/sound.bats
@@ -83,6 +83,28 @@ function setup() {
     unset python3
 }
 
+@test "function_detect_sound_scopes_helper_to_run_as_user" {
+    local python_args_file
+    python_args_file="$(mktemp /tmp/ovos-detect-sound-args.XXXXXX)"
+
+    function python3() {
+        printf '%s\n' "$*" >"$python_args_file"
+        echo "PipeWire"
+    }
+    export -f python3
+
+    touch "utils/detect_sound.py"
+
+    detect_sound
+    assert_equal "$SOUND_SERVER" "PipeWire"
+
+    run grep -q "utils/detect_sound.py testuser" "$python_args_file"
+    assert_success
+
+    rm -f "$python_args_file" "utils/detect_sound.py"
+    unset python3
+}
+
 function teardown() {
     rm -f "$LOG_FILE"
     if [ -n "$DETECT_SOUND_BACKUP" ]; then

--- a/utils/common.sh
+++ b/utils/common.sh
@@ -393,7 +393,7 @@ function detect_sound() {
     local python_detection
     # Use the Python helper to reliably detect the server name
     if [ -f "utils/detect_sound.py" ] && command -v python3 &>>"$LOG_FILE"; then
-        python_detection=$(python3 utils/detect_sound.py)
+        python_detection=$(python3 utils/detect_sound.py "${RUN_AS:-}")
     else
         python_detection="N/A"
     fi

--- a/utils/detect_sound.py
+++ b/utils/detect_sound.py
@@ -2,15 +2,20 @@ import os
 import platform
 import shutil
 import subprocess
+import sys
 
 
-def get_process_names():
-    """Return a set of running process names."""
+def get_process_names(username=None):
+    """Return a set of running process names for the target user."""
     try:
         pgrep_bin = shutil.which("pgrep")
         if not pgrep_bin:
             return set()
-        output = subprocess.check_output([pgrep_bin, "-a", "."], text=True).splitlines()
+        command = [pgrep_bin]
+        if username:
+            command.extend(["-u", username])
+        command.extend(["-a", "."])
+        output = subprocess.check_output(command, text=True).splitlines()
         processes = set()
         for line in output:
             parts = line.split(" ", 1)
@@ -22,13 +27,13 @@ def get_process_names():
         return set()
 
 
-def detect_sound_server():
-    """Detect the active sound server."""
+def detect_sound_server(username=None):
+    """Detect the active sound server for the target user/session."""
     if platform.system() == "Darwin":
         # macOS uses CoreAudio as the native audio stack.
         return "CoreAudio"
 
-    processes = get_process_names()
+    processes = get_process_names(username)
 
     has_pipewire = "pipewire" in processes
     has_pipewire_pulse = "pipewire-pulse" in processes
@@ -44,4 +49,4 @@ def detect_sound_server():
 
 
 if __name__ == "__main__":
-    print(detect_sound_server())
+    print(detect_sound_server(sys.argv[1] if len(sys.argv) > 1 else None))


### PR DESCRIPTION
Summary:
- scope Linux sound-server detection to the installer target user instead of the whole machine
- pass RUN_AS into the helper from the shell detection path
- add regression coverage for the helper invocation and helper implementation

Testing:
- bats tests/bats/sound.bats tests/bats/code_quality.bats
- python3 -m py_compile utils/detect_sound.py
- shellcheck -x -P . utils/common.sh