### PR TITLE
Increase container uninstall compose timeout

### DIFF
--- a/ansible/roles/ovos_containers/defaults/main.yml
+++ b/ansible/roles/ovos_containers/defaults/main.yml
@@ -93,7 +93,7 @@ ovos_containers_docker_compose_remove_orphans: "{{ ovos_installer_docker_compose
 ovos_containers_docker_compose_remove_images: "{{ ovos_installer_docker_compose_remove_images | default('all') }}"
 ovos_containers_docker_compose_remove_volumes: "{{ ovos_installer_docker_compose_remove_volumes | default(true) }}"
 ovos_containers_docker_timeout: "900"
-ovos_containers_compose_timeout: 1
+ovos_containers_compose_timeout: "{{ ovos_installer_docker_compose_timeout | default(30) }}"
 ovos_containers_compose_retries: "{{ ovos_installer_docker_compose_retries | default(3) }}"
 ovos_containers_compose_retry_delay: "{{ ovos_installer_docker_compose_retry_delay | default(2) }}"
 ovos_containers_compose_project_name: "{{ 'hivemind' if ovos_containers_profile == 'satellite' else 'ovos' }}"

--- a/tests/bats/code_quality.bats
+++ b/tests/bats/code_quality.bats
@@ -1078,6 +1078,7 @@ function setup() {
     local defaults_file="ansible/roles/ovos_containers/defaults/main.yml"
     local common_file="ansible/roles/ovos_containers/tasks/common.yml"
     local composer_file="ansible/roles/ovos_containers/tasks/composer.yml"
+    local uninstall_file="ansible/roles/ovos_containers/tasks/uninstall.yml"
 
     run grep -q "ovos_containers_repo_force_sync" "$defaults_file"
     assert_success
@@ -1089,6 +1090,12 @@ function setup() {
     assert_success
 
     run grep -q "ovos_containers_compose_retry_delay" "$defaults_file"
+    assert_success
+
+    run grep -q "ovos_containers_compose_timeout" "$defaults_file"
+    assert_success
+
+    run grep -q 'ovos_installer_docker_compose_timeout | default(30)' "$defaults_file"
     assert_success
 
     run grep -q "Check containers repository refresh markers" "$common_file"
@@ -1104,6 +1111,9 @@ function setup() {
     assert_success
 
     run grep -q "delay: \"{{ ovos_containers_compose_retry_delay | int }}\"" "$composer_file"
+    assert_success
+
+    run grep -q 'timeout: "{{ ovos_containers_compose_timeout }}"' "$uninstall_file"
     assert_success
 }
 


### PR DESCRIPTION
Summary:
- raise the default docker compose uninstall timeout from 1 second to a configurable 30-second default
- keep the timeout wired through the uninstall tasks
- add regression coverage for the new configurable default

Testing:
- bats tests/bats/code_quality.bats
- python3 YAML sanity check for ansible/roles/ovos_containers/defaults/main.yml