### PR TITLE
Disable ANSI color codes in installer logs

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -156,11 +156,11 @@ case "${DISTRO_NAME:-}" in
     ;;
 esac
 export ANSIBLE_NOCOWS=1
-if [ -t 1 ]; then
-  # ansible-playbook output is piped through tee, so force colors for interactive sessions.
-  export ANSIBLE_FORCE_COLOR=true
-  export PY_COLORS=1
-fi
+# ansible-playbook output is always piped through tee for logging, so keep it
+# plain text to avoid raw ANSI escapes in logs and pasted output.
+export ANSIBLE_NOCOLOR=true
+unset ANSIBLE_FORCE_COLOR || true
+unset PY_COLORS || true
 
 # Pass Home Assistant/LLM credentials via an extra-vars file
 # (avoids exposing secrets in the process list).

--- a/tests/bats/code_quality.bats
+++ b/tests/bats/code_quality.bats
@@ -2022,6 +2022,17 @@ function setup() {
     assert_success
 }
 
+@test "setup_disables_ansible_color_when_logging_through_tee" {
+    run grep -F -q "export ANSIBLE_NOCOLOR=true" setup.sh
+    assert_success
+
+    run grep -F -q "export ANSIBLE_FORCE_COLOR=true" setup.sh
+    assert_failure
+
+    run grep -F -q "export PY_COLORS=1" setup.sh
+    assert_failure
+}
+
 @test "common_defines_installer_lock_and_cleanup_helpers" {
     run grep -F -q "function acquire_installer_lock()" utils/common.sh
     assert_success


### PR DESCRIPTION
## Summary
- stop forcing Ansible color output from the installer entrypoint
- explicitly set plain-text Ansible output when the playbook is piped through tee
- add a regression check to keep forced color exports out of setup.sh

## Testing
- bats tests/bats/code_quality.bats --filter 'setup_uses_runtime_lock_and_signal_cleanup_hooks|setup_disables_ansible_color_when_logging_through_tee'
- shellcheck setup.sh (expected SC1091 source-following notices only)