### PR TITLE
Avoid failed status on clean service stops

### DIFF
--- a/ansible/roles/ovos_services/templates/virtualenv/hivemind-listener.service.j2
+++ b/ansible/roles/ovos_services/templates/virtualenv/hivemind-listener.service.j2
@@ -16,7 +16,6 @@ EnvironmentFile=-{{ ovos_installer_user_home }}/.config/environment.d/99-ovos-tu
 WorkingDirectory={{ ovos_installer_user_home if (ovos_installer_systemd_scope | default('user')) == 'system' else '%h' }}/.venvs/ovos
 ExecStart={{ ovos_installer_user_home if (ovos_installer_systemd_scope | default('user')) == 'system' else '%h' }}/.venvs/ovos/bin/hivemind-core listen
 ExecReload=/usr/bin/kill -s HUP $MAINPID
-ExecStop=/usr/bin/kill -s KILL $MAINPID
 Restart=on-failure
 RestartSec={{ '1s' if (ovos_installer_tuning | default(false) | bool) else '5s' }}
 

--- a/ansible/roles/ovos_services/templates/virtualenv/hivemind-satellite.service.j2
+++ b/ansible/roles/ovos_services/templates/virtualenv/hivemind-satellite.service.j2
@@ -18,7 +18,6 @@ EnvironmentFile=-{{ ovos_installer_user_home }}/.config/environment.d/99-ovos-tu
 WorkingDirectory={{ ovos_installer_user_home if (ovos_installer_systemd_scope | default('user')) == 'system' else '%h' }}/.venvs/ovos
 ExecStart={{ ovos_installer_user_home if (ovos_installer_systemd_scope | default('user')) == 'system' else '%h' }}/.venvs/ovos/bin/hivemind-voice-sat
 ExecReload=/usr/bin/kill -s HUP $MAINPID
-ExecStop=/usr/bin/kill -s KILL $MAINPID
 Restart=on-failure
 RestartSec={{ '1s' if (ovos_installer_tuning | default(false)) | bool else '5s' }}
 

--- a/ansible/roles/ovos_services/templates/virtualenv/ovos-audio.service.j2
+++ b/ansible/roles/ovos_services/templates/virtualenv/ovos-audio.service.j2
@@ -16,7 +16,6 @@ EnvironmentFile=-{{ ovos_installer_user_home }}/.config/environment.d/99-ovos-tu
 WorkingDirectory={{ ovos_installer_user_home if (ovos_installer_systemd_scope | default('user')) == 'system' else '%h' }}/.venvs/ovos
 ExecStart={{ ovos_installer_user_home if (ovos_installer_systemd_scope | default('user')) == 'system' else '%h' }}/.venvs/ovos/bin/ovos-audio
 ExecReload=/usr/bin/kill -s HUP $MAINPID
-ExecStop=/usr/bin/kill -s KILL $MAINPID
 Restart=on-failure
 RestartSec={{ '1s' if ovos_installer_tuning | bool else '5s' }}
 {% if ovos_installer_tuning_performance | bool and (ovos_installer_systemd_scope | default('user')) == 'system' %}

--- a/ansible/roles/ovos_services/templates/virtualenv/ovos-core.service.j2
+++ b/ansible/roles/ovos_services/templates/virtualenv/ovos-core.service.j2
@@ -20,7 +20,6 @@ EnvironmentFile=-{{ ovos_installer_user_home }}/.config/environment.d/99-ovos-tu
 WorkingDirectory={{ ovos_installer_user_home if (ovos_installer_systemd_scope | default('user')) == 'system' else '%h' }}/.venvs/ovos
 ExecStart={{ ovos_installer_user_home if (ovos_installer_systemd_scope | default('user')) == 'system' else '%h' }}/.venvs/ovos/bin/ovos-core
 ExecReload=/usr/bin/kill -s HUP $MAINPID
-ExecStop=/usr/bin/kill -s KILL $MAINPID
 Restart=on-failure
 RestartSec={{ '1s' if ovos_installer_tuning | bool else '5s' }}
 {% if ovos_installer_tuning_performance | bool and (ovos_installer_systemd_scope | default('user')) == 'system' %}

--- a/ansible/roles/ovos_services/templates/virtualenv/ovos-ggwave-listener.service.j2
+++ b/ansible/roles/ovos_services/templates/virtualenv/ovos-ggwave-listener.service.j2
@@ -16,7 +16,6 @@ EnvironmentFile=-{{ ovos_installer_user_home }}/.config/environment.d/99-ovos-tu
 WorkingDirectory={{ ovos_installer_user_home if (ovos_installer_systemd_scope | default('user')) == 'system' else '%h' }}/.venvs/ovos
 ExecStart={{ ovos_installer_user_home if (ovos_installer_systemd_scope | default('user')) == 'system' else '%h' }}/.venvs/ovos/bin/ovos-ggwave-listener
 ExecReload=/usr/bin/kill -s HUP $MAINPID
-ExecStop=/usr/bin/kill -s KILL $MAINPID
 Restart=on-failure
 RestartSec={{ '1s' if ovos_installer_tuning | bool else '5s' }}
 StartLimitBurst=0

--- a/ansible/roles/ovos_services/templates/virtualenv/ovos-gui-websocket.service.j2
+++ b/ansible/roles/ovos_services/templates/virtualenv/ovos-gui-websocket.service.j2
@@ -17,7 +17,6 @@ EnvironmentFile=-{{ ovos_installer_user_home }}/.config/environment.d/99-ovos-tu
 WorkingDirectory={{ ovos_installer_user_home if (ovos_installer_systemd_scope | default('user')) == 'system' else '%h' }}/.venvs/ovos
 ExecStart={{ ovos_installer_user_home if (ovos_installer_systemd_scope | default('user')) == 'system' else '%h' }}/.venvs/ovos/bin/ovos-gui-service
 ExecReload=/usr/bin/kill -s HUP $MAINPID
-ExecStop=/usr/bin/kill -s KILL $MAINPID
 Restart=on-failure
 RestartSec={{ '1s' if ovos_installer_tuning | bool else '5s' }}
 

--- a/ansible/roles/ovos_services/templates/virtualenv/ovos-gui.service.j2
+++ b/ansible/roles/ovos_services/templates/virtualenv/ovos-gui.service.j2
@@ -31,7 +31,6 @@ Environment="QT_IM_MODULE=qtvirtualkeyboard"
 {% endif %}
 ExecStart=/usr/bin/{{ 'ovos-shell' if _ovos_headless_display else 'ovos-gui-app' }}
 ExecReload=/usr/bin/kill -s HUP $MAINPID
-ExecStop=/usr/bin/kill -s KILL $MAINPID
 Restart=on-failure
 RestartSec={{ '1s' if ovos_installer_tuning | bool else '5s' }}
 

--- a/ansible/roles/ovos_services/templates/virtualenv/ovos-listener.service.j2
+++ b/ansible/roles/ovos_services/templates/virtualenv/ovos-listener.service.j2
@@ -18,7 +18,6 @@ EnvironmentFile=-{{ ovos_installer_user_home }}/.config/environment.d/99-ovos-tu
 WorkingDirectory={{ _ovos_service_user_home }}/.venvs/ovos
 ExecStart={{ _ovos_service_user_home }}/.venvs/ovos/bin/ovos-dinkum-listener
 ExecReload=/usr/bin/kill -s HUP $MAINPID
-ExecStop=/usr/bin/kill -s KILL $MAINPID
 Restart=on-failure
 RestartSec={{ '1s' if ovos_installer_tuning | bool else '5s' }}
 TimeoutStartSec=5min

--- a/ansible/roles/ovos_services/templates/virtualenv/ovos-messagebus.service.j2
+++ b/ansible/roles/ovos_services/templates/virtualenv/ovos-messagebus.service.j2
@@ -15,7 +15,6 @@ EnvironmentFile=-{{ ovos_installer_user_home }}/.config/environment.d/99-ovos-tu
 {% endif %}
 ExecStart={{ ovos_services_messagebus_command }}
 ExecReload=/usr/bin/kill -s HUP $MAINPID
-ExecStop=/usr/bin/kill -s KILL $MAINPID
 Restart=on-failure
 RestartSec={{ '1s' if ovos_installer_tuning | bool else '5s' }}
 

--- a/ansible/roles/ovos_services/templates/virtualenv/ovos-phal-admin.service.j2
+++ b/ansible/roles/ovos_services/templates/virtualenv/ovos-phal-admin.service.j2
@@ -9,7 +9,6 @@ Environment=XDG_CACHE_HOME={{ ovos_installer_user_home }}/.cache
 WorkingDirectory={{ ovos_installer_user_home }}/.venvs/ovos
 ExecStart=/usr/local/bin/wrapper-ovos-phal-admin.sh
 ExecReload=/usr/bin/kill -s HUP $MAINPID
-ExecStop=/usr/bin/kill -s KILL $MAINPID
 Restart=on-failure
 RestartSec={{ '1s' if ovos_installer_tuning | bool else '5s' }}
 

--- a/ansible/roles/ovos_services/templates/virtualenv/ovos-phal.service.j2
+++ b/ansible/roles/ovos_services/templates/virtualenv/ovos-phal.service.j2
@@ -35,7 +35,6 @@ ExecStartPre=/bin/bash -c 'for _ovos_retry in {1..30}; do [ -S /run/user/{{ ovos
 WorkingDirectory={{ ovos_installer_user_home if (ovos_installer_systemd_scope | default('user')) == 'system' else '%h' }}/.venvs/ovos
 ExecStart={{ ovos_installer_user_home if (ovos_installer_systemd_scope | default('user')) == 'system' else '%h' }}/.venvs/ovos/bin/ovos_PHAL
 ExecReload=/usr/bin/kill -s HUP $MAINPID
-ExecStop=/usr/bin/kill -s KILL $MAINPID
 Restart=on-failure
 RestartSec={{ '1s' if ovos_installer_tuning | default(false) | bool else '5s' }}
 

--- a/tests/bats/code_quality.bats
+++ b/tests/bats/code_quality.bats
@@ -1895,6 +1895,11 @@ function setup() {
     assert_failure
 }
 
+@test "virtualenv_systemd_units_do_not_force_kill_on_stop" {
+    run rg -n 'ExecStop=/usr/bin/kill -s KILL \\$MAINPID' ansible/roles/ovos_services/templates/virtualenv
+    assert_failure
+}
+
 @test "setup_exports_collection_paths_for_launchd_module_resolution" {
     run grep -q "ANSIBLE_COLLECTIONS_PATH" setup.sh
     assert_success


### PR DESCRIPTION
## Summary
- stop relying on `ExecStop=/usr/bin/kill -s KILL $MAINPID` in the virtualenv systemd units
- let systemd handle normal service termination so manual stops do not appear as failures
- add regression coverage to keep the virtualenv unit templates free of forced stop kills

## Root Cause
On the Mark 2 device, `ovos-gui.service` had started successfully and was then stopped manually with `sudo systemctl stop ovos-gui`. The unit template forced a SIGKILL in `ExecStop`, so systemd recorded the stop as `failed (signal)` even though it was an intentional stop.

## Validation
- verified from the Mark 2 journal that the GUI was manually stopped after startup
- bats tests/bats/code_quality.bats --filter "gui_systemd_units_have_ordering_and_no_venv_workdir|virtualenv_systemd_units_do_not_force_kill_on_stop"