### PR TITLE
Fix skipped reboot handler on install

### DIFF
--- a/ansible/roles/ovos_installer/tasks/main.yml
+++ b/ansible/roles/ovos_installer/tasks/main.yml
@@ -28,7 +28,7 @@
     - always
 
 - name: Include ovos_services role for uninstall pre-stop
-  ansible.builtin.import_role:
+  ansible.builtin.include_role:
     name: ovos_services
   when: ovos_installer_is_cleaning | bool
   tags:

--- a/tests/bats/code_quality.bats
+++ b/tests/bats/code_quality.bats
@@ -833,6 +833,12 @@ function setup() {
     run bash -c "grep -A8 -F -- \"- name: Include ovos_services role for uninstall pre-stop\" \"$file\" | grep -F -q -- \"ovos_installer_is_cleaning\""
     assert_success
 
+    run bash -c "grep -A3 -F -- \"- name: Include ovos_services role for uninstall pre-stop\" \"$file\" | grep -F -q -- \"ansible.builtin.include_role:\""
+    assert_success
+
+    run bash -c "grep -A3 -F -- \"- name: Include ovos_services role for uninstall pre-stop\" \"$file\" | grep -F -q -- \"ansible.builtin.import_role:\""
+    assert_failure
+
     run bash -c "grep -A6 -F -- \"- name: Include ovos_services role\" \"$file\" | grep -F -q -- \"not (ovos_installer_is_cleaning | bool)\""
     assert_success
 }


### PR DESCRIPTION
## Summary
- switch the uninstall pre-stop `ovos_services` load to `include_role` so its handlers are not statically imported on install runs
- prevent the cleaning-only `ovos_services` handler set from shadowing the normal install-time handlers
- add a code-quality guard so the pre-stop role load stays dynamic

## Why
On the Mark 2 install from March 8, 2026, `/var/log/ovos-ansible.log` showed `RUNNING HANDLER [ovos_services : Set Reboot]` followed by `skipping: [127.0.0.1]`, and the final `Checking for reboot requirement` task also skipped. The reboot notify tasks from `#488` were present on `main`, but the statically imported cleaning-only `ovos_services` role instance was still loading its handlers and shadowing the install-time handler resolution.

## Validation
- `bats tests/bats/code_quality.bats --filter 'installer_stops_services_early_on_uninstall|mark2_boot_config_changes_flag_reboot|performance_tuning_boot_and_cmdline_changes_flag_reboot'`
- `ansible-playbook --syntax-check -i localhost, -c local ansible/site.yml` *(still blocked by the existing missing `moreati.uv` collection in this environment)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated uninstall pre-stop execution behavior.

* **Tests**
  * Added validation for uninstall pre-stop execution method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->