### PR TITLE
Fix reboot handler leaks from uninstall imports

### DIFF
--- a/ansible/roles/ovos_installer/tasks/main.yml
+++ b/ansible/roles/ovos_installer/tasks/main.yml
@@ -102,7 +102,7 @@
     - ovos_telemetry
 
 - name: Include uninstall tasks
-  ansible.builtin.import_tasks: uninstall.yml
+  ansible.builtin.include_tasks: uninstall.yml
   when: ovos_installer_is_cleaning | bool
   tags:
     - uninstall

--- a/ansible/roles/ovos_installer/tasks/uninstall.yml
+++ b/ansible/roles/ovos_installer/tasks/uninstall.yml
@@ -1,8 +1,9 @@
 ---
 - name: Remove OVOS service directories after tuning cleanup
-  ansible.builtin.import_role:
+  ansible.builtin.include_role:
     name: ovos_services
     tasks_from: remove-directories.yml
+    handlers_from: noop
   when:
     - ansible_facts.system == 'Linux'
 

--- a/tests/bats/code_quality.bats
+++ b/tests/bats/code_quality.bats
@@ -847,14 +847,29 @@ function setup() {
 
     run bash -c "grep -A6 -F -- \"- name: Include ovos_services role\" \"$file\" | grep -F -q -- \"not (ovos_installer_is_cleaning | bool)\""
     assert_success
+
+    run bash -c "grep -A4 -F -- \"- name: Include uninstall tasks\" \"$file\" | grep -F -q -- \"ansible.builtin.include_tasks: uninstall.yml\""
+    assert_success
+
+    run bash -c "grep -A4 -F -- \"- name: Include uninstall tasks\" \"$file\" | grep -F -q -- \"ansible.builtin.import_tasks: uninstall.yml\""
+    assert_failure
 }
 
 @test "installer_removes_service_directories_after_tuning_cleanup" {
     local uninstall_file="ansible/roles/ovos_installer/tasks/uninstall.yml"
     local services_uninstall_file="ansible/roles/ovos_services/tasks/uninstall.yml"
 
-    run bash -c "grep -A4 -F -- \"- name: Remove OVOS service directories after tuning cleanup\" \"$uninstall_file\" | grep -F -q -- \"tasks_from: remove-directories.yml\""
+    run bash -c "grep -A5 -F -- \"- name: Remove OVOS service directories after tuning cleanup\" \"$uninstall_file\" | grep -F -q -- \"ansible.builtin.include_role:\""
     assert_success
+
+    run bash -c "grep -A5 -F -- \"- name: Remove OVOS service directories after tuning cleanup\" \"$uninstall_file\" | grep -F -q -- \"tasks_from: remove-directories.yml\""
+    assert_success
+
+    run bash -c "grep -A5 -F -- \"- name: Remove OVOS service directories after tuning cleanup\" \"$uninstall_file\" | grep -F -q -- \"handlers_from: noop\""
+    assert_success
+
+    run bash -c "grep -A5 -F -- \"- name: Remove OVOS service directories after tuning cleanup\" \"$uninstall_file\" | grep -F -q -- \"ansible.builtin.import_role:\""
+    assert_failure
 
     run bash -c 'remove_line=$(grep -n -F -- "- name: Remove OVOS service directories after tuning cleanup" "$1" | head -n1 | cut -d: -f1); autoremove_line=$(grep -n -F -- "- name: Autoremove orphaned packages (Debian/Zorin)" "$1" | head -n1 | cut -d: -f1); [ -n "$remove_line" ] && [ -n "$autoremove_line" ] && [ "$remove_line" -lt "$autoremove_line" ]' _ "$uninstall_file"
     assert_success


### PR DESCRIPTION
## Summary
- switch the top-level uninstall task load from `import_tasks` to `include_tasks`
- switch the uninstall-time `ovos_services` cleanup load from `import_role` to `include_role`
- keep the cleanup-only `ovos_services` load on `handlers_from: noop` so it cannot register install-time handlers
- extend the regression checks to cover both dynamic include paths and the cleanup role wiring

## Why
This is the last reboot follow-up after `#488`, `#491`, and `#492`.

- `#488` fixed the missing `notify: Set Reboot` calls for Mark II boot config and Raspberry Pi tuning changes.
- `#491` stopped the uninstall pre-stop role load in `main.yml` from using `import_role`.
- `#492` pointed that pre-stop role load at `handlers_from: noop` so it would not register the normal install handlers.

That still left one more static uninstall import chain on normal install runs:

- `ansible/roles/ovos_installer/tasks/main.yml` still used `import_tasks: uninstall.yml`
- `ansible/roles/ovos_installer/tasks/uninstall.yml` still used `import_role` for the cleanup-only `ovos_services` directory removal

Under Ansible 2.20, that was still enough to leak cleanup-scoped `ovos_services` handlers into a normal install run. The result on the Mark II was:

- `RUNNING HANDLER [ovos_services : Set Reboot]`
- immediately followed by `skipping: [127.0.0.1]`
- and later `TASK [Checking for reboot requirement]` also skipped

So the install changed reboot-required boot config, but `/tmp/ovos.reboot` was never created.

This PR removes that last static import path by making both uninstall loads dynamic at runtime.

## Mark II Validation
Validated on the actual Mark II on Monday, March 9, 2026.

Before this patch, the fresh-install logs showed the reboot handler still skipping and no reboot flag creation.

After this patch:
- `RUNNING HANDLER [ovos_services : Set Reboot]` logged `ok`
- `TASK [Checking for reboot requirement]` changed and created `/tmp/ovos.reboot`
- closing the finish screen printed `Rebooting Raspberry Pi now...`
- the device disconnected and came back with a new boot time
- `ovos.service` and `ovos-gui.service` were active after boot

## Testing
- `bats tests/bats/code_quality.bats --filter 'installer_stops_services_early_on_uninstall|installer_removes_service_directories_after_tuning_cleanup|mark2_boot_config_changes_flag_reboot|performance_tuning_boot_and_cmdline_changes_flag_reboot'`
