### PR TITLE
Pin compatible common query package stack

### DIFF
--- a/ansible/roles/ovos_virtualenv/templates/virtualenv/core-requirements.txt.j2
+++ b/ansible/roles/ovos_virtualenv/templates/virtualenv/core-requirements.txt.j2
@@ -10,6 +10,14 @@ ovos-ww-plugin-precise-onnx
 {% endif %}
 {% endif %}
 ovos-docs-viewer
+# Keep common-query defaults on a compatible published stack until the alpha
+# Wikipedia/DDG packages stop breaking solver interfaces and transitive deps.
+ovos-skill-ddg==0.3.6
+ovos-wikipedia-solver==0.1.3
+crf-query-xtract==0.2.0
+brill-postagger==0.1.2
+nltk==3.9.3
+sklearn-crfsuite==0.5.0
 {% if ovos_installer_feature_gui | bool %}
 ovos-gui[extras]
 ovos-skill-homescreen

--- a/tests/bats/code_quality.bats
+++ b/tests/bats/code_quality.bats
@@ -899,6 +899,28 @@ function setup() {
     assert_failure
 }
 
+@test "virtualenv_core_requirements_pin_compatible_common_query_packages" {
+    local file="ansible/roles/ovos_virtualenv/templates/virtualenv/core-requirements.txt.j2"
+
+    run grep -F -q "ovos-skill-ddg==0.3.6" "$file"
+    assert_success
+
+    run grep -F -q "ovos-wikipedia-solver==0.1.3" "$file"
+    assert_success
+
+    run grep -F -q "crf-query-xtract==0.2.0" "$file"
+    assert_success
+
+    run grep -F -q "brill-postagger==0.1.2" "$file"
+    assert_success
+
+    run grep -F -q "nltk==3.9.3" "$file"
+    assert_success
+
+    run grep -F -q "sklearn-crfsuite==0.5.0" "$file"
+    assert_success
+}
+
 @test "virtualenv_mark2_uses_phal_mk2_without_pyee_pin" {
     local file="ansible/roles/ovos_virtualenv/templates/virtualenv/core-requirements.txt.j2"
 


### PR DESCRIPTION
## Summary
- pin the virtualenv common-query stack to compatible published versions
- add the missing runtime deps needed by the older DDG stack
- add a regression guard for the pinned package set

## Why
A fresh Mark II install was pulling an incompatible alpha common-query stack:
- `ovos-skill-wikipedia 0.8.14a3`
- `ovos-wikipedia-solver 0.1.4a5`
- `ovos-skill-ddg 0.3.7a4`

On device this produced two runtime failures:
- Wikipedia skill called `self.wiki.extract_keyword(...)`, but `ovos-wikipedia-solver 0.1.4a*` no longer provides `extract_keyword`
- DDG skill 0.3.7a* switched to `ovos-ddg-solver-plugin`, which expects a keyword-extractor plugin entry point that is not available from the published package set

The known-good published fallback is:
- `ovos-skill-ddg==0.3.6`
- `ovos-wikipedia-solver==0.1.3`

The older DDG stack also needs two undeclared runtime deps from its transitive packages:
- `nltk`
- `sklearn-crfsuite`

## Mark II Validation
Validated on the Mark II after downgrading the live venv to the pinned stack.

Verified on device:
- `ovos-wikipedia-solver 0.1.3`
- `ovos-skill-ddg 0.3.6`
- `crf-query-xtract 0.2.0`
- `brill-postagger 0.1.2`
- `nltk 3.9.3`
- `sklearn-crfsuite 0.5.0`

After restart:
- the previous `AttributeError: 'WikipediaSolver' object has no attribute 'extract_keyword'` path was gone
- the previous DDG `AttributeError: 'NoneType' object has no attribute 'extract'` path was gone from startup
- direct solver import/extraction probes on the device completed successfully

## Testing
- `bats tests/bats/code_quality.bats --filter 'virtualenv_core_requirements_do_not_pin_noninstallable_pipeline_plugins|virtualenv_core_requirements_pin_compatible_common_query_packages'`
