### PR TITLE
Persist LLM tuning state as numeric JSON

### DIFF
--- a/tests/bats/scenario_processing.bats
+++ b/tests/bats/scenario_processing.bats
@@ -544,11 +544,13 @@ EOF
         source tui/llm.sh
         printf "%s|%s|%s\\n" "$LLM_API_URL" "$LLM_MODEL" "$LLM_TOP_P"
         jq -r "\"\\(.llm.api_url)|\\(.llm.top_p|tostring)\"" "$INSTALLER_STATE_FILE"
+        jq -r "\"\\(.llm.max_tokens|type)|\\(.llm.temperature|type)|\\(.llm.top_p|type)\"" "$INSTALLER_STATE_FILE"
     ' _ "$PWD" "$scenario_file" "$yq_mock" "$state_file" "$log_file" "$run_as_home"
 
     assert_success
     assert_line --index 0 "http://llama.smartgic.io/v1|qwen3-nothink:latest|0.6"
     assert_line --index 1 "http://llama.smartgic.io/v1|0.6"
+    assert_line --index 2 "number|number|number"
 
     rm -f "$scenario_file" "$yq_mock" "$state_file" "$log_file"
     rm -rf "$run_as_home"

--- a/tests/bats/tui_lists.bats
+++ b/tests/bats/tui_lists.bats
@@ -496,6 +496,10 @@ function dialog_value() {
     run jq -r '"\(.llm.api_url)|\(.llm.model)|\(.llm.max_tokens|tostring)|\(.llm.temperature|tostring)|\(.llm.top_p|tostring)"' "$INSTALLER_STATE_FILE"
     assert_success
     assert_output "https://llama.smartgic.io/v1|qwen3-nothink:latest|300|0.2|0.1"
+
+    run jq -r '"\(.llm.max_tokens|type)|\(.llm.temperature|type)|\(.llm.top_p|type)"' "$INSTALLER_STATE_FILE"
+    assert_success
+    assert_output "number|number|number"
 }
 
 @test "llm: invalid url shows the URL-specific validation message" {
@@ -586,6 +590,10 @@ EOF
     run jq -r '"\(.llm.api_url)|\(.llm.model)|\(.llm.max_tokens|tostring)|\(.llm.temperature|tostring)|\(.llm.top_p|tostring)"' "$INSTALLER_STATE_FILE"
     assert_success
     assert_output "https://llama.smartgic.io/v1|qwen3-nothink:latest|320|0.2|0.1"
+
+    run jq -r '"\(.llm.max_tokens|type)|\(.llm.temperature|type)|\(.llm.top_p|type)"' "$INSTALLER_STATE_FILE"
+    assert_success
+    assert_output "number|number|number"
 }
 
 @test "llm: invalid preseeded tuning values fall back to validated prompt defaults" {

--- a/tui/llm.sh
+++ b/tui/llm.sh
@@ -134,7 +134,7 @@ persist_llm_state() {
   state_tmp="$(mktemp)"
   if [ -f "$INSTALLER_STATE_FILE" ]; then
     if jq --arg api_url "$LLM_API_URL" --arg model "$LLM_MODEL" --arg persona "$LLM_PERSONA" \
-      --arg max_tokens "$LLM_MAX_TOKENS" --arg temperature "$LLM_TEMPERATURE" --arg top_p "$LLM_TOP_P" \
+      --argjson max_tokens "$LLM_MAX_TOKENS" --argjson temperature "$LLM_TEMPERATURE" --argjson top_p "$LLM_TOP_P" \
       'if type=="object" then . else {} end
        | .llm = ((.llm // {}) + {api_url: $api_url, model: $model, persona: $persona, max_tokens: $max_tokens, temperature: $temperature, top_p: $top_p})' \
       "$INSTALLER_STATE_FILE" >"$state_tmp" 2>>"$LOG_FILE"; then
@@ -145,7 +145,7 @@ persist_llm_state() {
     fi
   else
     if jq -n --arg api_url "$LLM_API_URL" --arg model "$LLM_MODEL" --arg persona "$LLM_PERSONA" \
-      --arg max_tokens "$LLM_MAX_TOKENS" --arg temperature "$LLM_TEMPERATURE" --arg top_p "$LLM_TOP_P" \
+      --argjson max_tokens "$LLM_MAX_TOKENS" --argjson temperature "$LLM_TEMPERATURE" --argjson top_p "$LLM_TOP_P" \
       '{llm: {api_url: $api_url, model: $model, persona: $persona, max_tokens: $max_tokens, temperature: $temperature, top_p: $top_p}}' >"$state_tmp" 2>>"$LOG_FILE"; then
       mv -f "$state_tmp" "$INSTALLER_STATE_FILE"
     else


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of LLM configuration parameters (max_tokens, temperature, top_p) to ensure correct numeric type processing during state persistence.

* **Tests**
  * Added type validation tests to verify LLM configuration parameters are correctly processed as numeric values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->