### PR TITLE
Tighten Mark II I2C detection on Raspberry Pi

### DIFF
--- a/tests/bats/hardware_detection.bats
+++ b/tests/bats/hardware_detection.bats
@@ -85,7 +85,7 @@ function setup() {
     assert_success
 }
 
-@test "function_i2c_scan_recovers_mark2_from_installer_state_when_live_scan_misses" {
+@test "function_i2c_scan_does_not_restore_cached_mark2_state_when_live_scan_misses" {
     RASPBERRYPI_MODEL="Raspberry Pi 4"
     DISTRO_NAME="debian"
     DISTRO_VERSION_ID="13"
@@ -112,17 +112,17 @@ EOF
         return 0
     }
     function i2c_get() {
-        return 1  # Live scan misses; should recover from state.
+        return 1
     }
     export -f dtparam lsmod modprobe i2c_get
 
     i2c_scan
     assert_equal "$?" "0"
 
-    has_detected_device "tas5806"
-    assert_equal "$?" "0"
-    assert_equal "$DISPLAY_SERVER" "eglfs"
-    assert_equal "$CHANNEL" "alpha"
+    run has_detected_device "tas5806"
+    assert_failure
+    assert_equal "$DISPLAY_SERVER" "N/A"
+    assert_equal "$CHANNEL" "testing"
 
     rm -rf "$RUN_AS_HOME"
 }
@@ -175,6 +175,51 @@ EOF
     run i2c_scan
     assert_success
     # Should not attempt I2C operations
+}
+
+@test "function_i2c_scan_ignores_non_primary_bus_false_positives_by_default" {
+    run bash -lc "
+        source '$BATS_TEST_DIRNAME/../../utils/constants.sh'
+        source '$BATS_TEST_DIRNAME/../../utils/common.sh'
+        LOG_FILE=\"\$(mktemp /tmp/ovos-installer-bats.XXXXXX)\"
+        RASPBERRYPI_MODEL='Raspberry Pi 5'
+        I2C_BUS='1'
+        DISTRO_NAME='debian'
+        DISTRO_VERSION_ID='13'
+        DISTRO_VERSION='Debian GNU/Linux 13 (trixie)'
+        DISPLAY_SERVER='N/A'
+        CHANNEL='testing'
+        FEATURE_GUI='false'
+        DETECTED_DEVICES=()
+
+        dtparam() { return 0; }
+        lsmod() { return 0; }
+        modprobe() { return 0; }
+        i2cdetect() {
+            printf 'i2c-bus:%s\n' \"\$3\" >>\"\$LOG_FILE\"
+            if [[ \"\$3\" == '13' ]]; then
+                printf '%s\n' '2f'
+            else
+                printf '\n'
+            fi
+        }
+        export -f dtparam lsmod modprobe i2cdetect
+
+        i2c_scan >/dev/null
+        if has_detected_device 'tas5806'; then
+            printf '%s\n' 'tas5806:present'
+        else
+            printf '%s\n' 'tas5806:absent'
+        fi
+        printf 'feature_gui:%s\n' \"\$FEATURE_GUI\"
+        printf 'channel:%s\n' \"\$CHANNEL\"
+        grep -o 'i2c-bus:[0-9]\\+' \"\$LOG_FILE\" | sort -u
+    "
+    assert_success
+    assert_output --partial "tas5806:absent"
+    assert_output --partial "feature_gui:false"
+    assert_output --partial "channel:testing"
+    assert_output --partial "i2c-bus:1"
 }
 
 @test "function_enforce_mark2_devkit_trixie_requirement_accepts_debian_trixie" {

--- a/tests/bats/i2c.bats
+++ b/tests/bats/i2c.bats
@@ -28,6 +28,26 @@ function setup() {
     unset i2cdetect
 }
 
+@test "function_install_i2c_get_uses_only_primary_bus_by_default" {
+    I2C_BUS="1"
+    export I2C_BUS
+
+    function i2cdetect() {
+        if [[ "$3" == "13" ]]; then
+            echo "2f"
+        else
+            echo ""
+        fi
+    }
+    export -f i2cdetect
+
+    run i2c_get "2f"
+    assert_failure
+
+    unset i2cdetect
+    unset I2C_BUS
+}
+
 @test "function_install_i2c_get_falls_back_to_other_buses" {
     OVOS_I2C_SCAN_BUSES="1 10"
     export OVOS_I2C_SCAN_BUSES

--- a/utils/common.sh
+++ b/utils/common.sh
@@ -1398,11 +1398,11 @@ function ver() {
 
 # Check if a specific hexadecimal address exists on the I2C bus.
 # Takes an argument like "2f" which is converted to "0x2f".
-# Only used when a Raspberry Pi board is detected.
+# By default only the primary I2C bus is probed; additional buses must be
+# explicitly requested through OVOS_I2C_SCAN_BUSES.
 function i2c_get() {
     local address="$1"
     local bus=""
-    local bus_dev=""
     local -a i2c_buses=()
     local override_buses="${OVOS_I2C_SCAN_BUSES:-}"
 
@@ -1415,19 +1415,7 @@ function i2c_get() {
         # Accept either comma- or space-separated values.
         read -r -a i2c_buses <<<"${override_buses//,/ }"
     else
-        if [ -n "${I2C_BUS:-}" ]; then
-            i2c_buses+=("$I2C_BUS")
-        fi
-
-        for bus_dev in /dev/i2c-*; do
-            [ -e "$bus_dev" ] || continue
-            bus="${bus_dev##*-}"
-            [[ "$bus" =~ ^[0-9]+$ ]] || continue
-
-            if [ "$bus" != "${I2C_BUS:-}" ]; then
-                i2c_buses+=("$bus")
-            fi
-        done
+        i2c_buses+=("${I2C_BUS:-1}")
     fi
 
     for bus in "${i2c_buses[@]}"; do
@@ -1471,15 +1459,6 @@ function i2c_scan() {
             fi
         done
 
-        # If the live scan does not detect any supported devices during an
-        # existing-install rerun, recover the last known I2C device list from
-        # installer state to keep Mark II/DevKit gating deterministic.
-        if [ "${EXISTING_INSTANCE:-false}" == "true" ] && \
-            ! has_detected_device "atmega328p" && \
-            ! has_detected_device "attiny1614" && \
-            ! has_detected_device "tas5806"; then
-            restore_detected_devices_from_state || true
-        fi
         echo -e "[$done_format]"
     fi
 
@@ -1500,44 +1479,6 @@ function has_detected_device() {
             return 0
         fi
     done
-
-    return 1
-}
-
-# Restore known I2C devices from installer state when live probing did not
-# detect anything (for example, re-runs after partial installs).
-function restore_detected_devices_from_state() {
-    local run_as_home="${RUN_AS_HOME:-}"
-    local state_file="${INSTALLER_STATE_FILE:-}"
-    local cached_device=""
-    local restored_device="false"
-
-    if [ -z "$state_file" ]; then
-        if [ -z "$run_as_home" ]; then
-            return 1
-        fi
-        state_file="${run_as_home}/.local/state/ovos/installer.json"
-    fi
-
-    if [ ! -f "$state_file" ] || ! command -v jq &>>"$LOG_FILE"; then
-        return 1
-    fi
-
-    while IFS= read -r cached_device; do
-        case "$cached_device" in
-        atmega328p | attiny1614 | tas5806)
-            if ! has_detected_device "$cached_device"; then
-                DETECTED_DEVICES+=("$cached_device")
-                restored_device="true"
-            fi
-            ;;
-        esac
-    done < <(jq -r '.i2c_devices[]? // empty' "$state_file" 2>>"$LOG_FILE")
-
-    if [ "$restored_device" == "true" ]; then
-        printf '%s\n' "[info] Restored detected I2C devices from installer state: ${DETECTED_DEVICES[*]}" &>>"$LOG_FILE"
-        return 0
-    fi
 
     return 1
 }


### PR DESCRIPTION
## Summary
- stop probing every /dev/i2c-* by default and only probe the primary bus unless OVOS_I2C_SCAN_BUSES is explicitly set
- stop restoring cached I2C hardware state into live detection on reruns
- add Bats coverage for non-primary-bus false positives and stale cached-state contamination

## Why
On `mm01` the installer was treating a non-Mark II/DevKit Pi 5 as GUI-capable because the shell detector walked all I2C buses and accepted raw address hits from unrelated buses. Live evidence from the device:
- `/usr/sbin/i2cdetect -y -a 1` was empty
- `/usr/sbin/i2cdetect -y -a 13` and `14` acknowledged nearly every address
- the installer log therefore recorded false hits for `0x2f` / `0x04`
- reruns could keep reusing the bad `tas5806` / `attiny1614` state from `installer.json`

The fix is to make live probing deterministic on the primary bus and stop rehydrating hardware identity from cached installer state. `state_directory()` still persists the latest live detection, but it is no longer used to override a live miss.

## Validation
- `bash -n utils/common.sh tests/bats/i2c.bats tests/bats/hardware_detection.bats`
- `shellcheck -x -P . utils/common.sh`
- `bats tests/bats/i2c.bats`
- `bats tests/bats/hardware_detection.bats`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * I2C scanning now defaults to the primary bus unless explicitly overridden.

* **Bug Fixes**
  * Removed fallback restoration of previously detected devices; live scans rely on current probe results.

* **Tests**
  * Added tests ensuring primary-bus-only probing and that non-primary-bus false positives are ignored by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->