### PR TITLE
Move padatious cache staging out of tmpfs

### DIFF
--- a/ansible/roles/ovos_virtualenv/defaults/main.yml
+++ b/ansible/roles/ovos_virtualenv/defaults/main.yml
@@ -61,7 +61,7 @@ ovos_virtualenv_setuptools_package: "{{ ovos_installer_setuptools_package | defa
 ovos_virtualenv_repair_ownership: "{{ ovos_installer_repair_venv_ownership | default(false) }}"
 ovos_virtualenv_padatious_cache_repo_url: https://github.com/OpenVoiceOS/padatious_cache
 ovos_virtualenv_padatious_cache_repo_version: dev
-ovos_virtualenv_padatious_cache_repo_path: "{{ ovos_virtualenv_tmp_dir }}/padatious_cache"
+ovos_virtualenv_padatious_cache_repo_path: "{{ ovos_installer_user_home }}/.cache/ovos-installer/padatious_cache"
 ovos_virtualenv_padatious_cache_repo_refresh_interval: 21600
 ovos_virtualenv_gui_repo_refresh_interval: "{{ ovos_installer_gui_repo_refresh_interval | default(21600) }}"
 ovos_virtualenv_gui_repo_force_sync: "{{ ovos_installer_gui_repo_force_sync | default(false) }}"
@@ -132,6 +132,7 @@ ovos_virtualenv_macos_packages:
 ovos_virtualenv_uninstall_extra_paths:
   - "{{ ovos_hardware_mark1_working_directory | default('/opt/mark1') }}"
   - "{{ ovos_hardware_mark2_working_dir | default('/opt/sj201') }}"
+  - "{{ ovos_virtualenv_padatious_cache_repo_path }}"
   - "{{ ovos_virtualenv_padatious_cache_dir }}"
   - "{{ ovos_virtualenv_padatious_cache_staging_dir }}"
   - "{{ ovos_virtualenv_padatious_cache_backup_dir }}"

--- a/ansible/roles/ovos_virtualenv/tasks/assert.yml
+++ b/ansible/roles/ovos_virtualenv/tasks/assert.yml
@@ -18,6 +18,7 @@
   loop:
     - "{{ ovos_virtualenv_path }}"
     - "{{ ovos_virtualenv_root_dir }}"
+    - "{{ ovos_virtualenv_padatious_cache_repo_path }}"
     - "{{ ovos_virtualenv_tmp_dir }}"
     - "{{ ovos_virtualenv_rust_messagebus_archive_path }}"
     - "{{ ovos_virtualenv_rust_messagebus_binary_path }}"

--- a/ansible/roles/ovos_virtualenv/tasks/intent_cache.yml
+++ b/ansible/roles/ovos_virtualenv/tasks/intent_cache.yml
@@ -19,6 +19,14 @@
       }}
   changed_when: false
 
+- name: Ensure padatious cache repository parent directory exists
+  ansible.builtin.file:
+    path: "{{ ovos_virtualenv_padatious_cache_repo_path | dirname }}"
+    state: directory
+    owner: "{{ ovos_installer_user }}"
+    group: "{{ ovos_installer_group }}"
+    mode: "0755"
+
 - name: Checkout padatious cache repository
   ansible.builtin.git:
     repo: "{{ ovos_virtualenv_padatious_cache_repo_url }}"

--- a/tests/bats/code_quality.bats
+++ b/tests/bats/code_quality.bats
@@ -985,6 +985,9 @@ function setup() {
     run grep -F -q "ovos_virtualenv_padatious_cache_repo_version: dev" "$defaults_file"
     assert_success
 
+    run grep -F -q 'ovos_virtualenv_padatious_cache_repo_path: "{{ ovos_installer_user_home }}/.cache/ovos-installer/padatious_cache"' "$defaults_file"
+    assert_success
+
     run grep -F -q "ovos_virtualenv_padatious_cache_dir:" "$defaults_file"
     assert_success
 
@@ -1007,6 +1010,12 @@ function setup() {
     assert_success
 
     run bash -c "grep -A10 -F -- \"- name: Checkout padatious cache repository\" \"$cache_tasks_file\" | grep -F -q -- \"version: \\\"{{ ovos_virtualenv_padatious_cache_repo_version }}\\\"\""
+    assert_success
+
+    run grep -F -q "Ensure padatious cache repository parent directory exists" "$cache_tasks_file"
+    assert_success
+
+    run bash -c "grep -A6 -F -- \"- name: Ensure padatious cache repository parent directory exists\" \"$cache_tasks_file\" | grep -F -q -- \"{{ ovos_virtualenv_padatious_cache_repo_path | dirname }}\""
     assert_success
 
     run grep -F -q "Check staged OVOS intent cache payload exists" "$cache_tasks_file"
@@ -1046,6 +1055,12 @@ function setup() {
     assert_success
 
     run grep -F -q -- "- \"{{ ovos_virtualenv_padatious_cache_backup_dir }}\"" "$defaults_file"
+    assert_success
+
+    run grep -F -q -- "- \"{{ ovos_virtualenv_padatious_cache_repo_path }}\"" "$defaults_file"
+    assert_success
+
+    run grep -F -q -- '- "{{ ovos_virtualenv_padatious_cache_repo_path }}"' "ansible/roles/ovos_virtualenv/tasks/assert.yml"
     assert_success
 }
 


### PR DESCRIPTION
## Summary
- move the padatious cache repository checkout out of  and into 
- ensure the repo parent directory exists before the git checkout runs
- extend the virtualenv path guards and code-quality coverage for the new repo path

## Why
The playbook failed on  in  because  is a 512 MB tmpfs on that node, and  filled it during checkout. The root filesystem still had ample free space, so the failure was specific to staging this large repository under .

## Validation
- 1..1
ok 1 virtualenv_installs_padatious_cache_for_all_virtualenv_installs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved cache persistence by moving padatious cache storage location from a temporary directory to a persistent user home directory, ensuring cache survives across sessions.
  * Updated configuration validation to properly track all cache-related paths.

* **Tests**
  * Added comprehensive validation tests to verify cache directory configuration, parent directory existence, and path format compliance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->