### PR TITLE
Bump rust messagebus to v2.0.0

### DIFF
--- a/ansible/roles/ovos_virtualenv/defaults/main.yml
+++ b/ansible/roles/ovos_virtualenv/defaults/main.yml
@@ -71,7 +71,7 @@ ovos_virtualenv_padatious_cache_backup_dir: "{{ ovos_virtualenv_padatious_cache_
 ovos_virtualenv_padatious_cache_force_sync: "{{ ovos_installer_padatious_cache_force_sync | default(false) }}"
 ovos_virtualenv_messagebus_path: "{{ ovos_installer_user_home }}/.local/bin/ovos-messagebus"
 ovos_virtualenv_rust_messagebus_repo: https://github.com/OscillateLabsLLC/ovos-rust-messagebus
-ovos_virtualenv_rust_messagebus_version: v1.1.2
+ovos_virtualenv_rust_messagebus_version: v2.0.0
 ovos_virtualenv_rust_messagebus_target_arch: >-
   {{ 'aarch64' if (ansible_facts.architecture | default('')) in ['aarch64', 'arm64']
      else 'x86_64' if (ansible_facts.architecture | default('')) in ['x86_64', 'amd64']
@@ -88,12 +88,12 @@ ovos_virtualenv_rust_messagebus_archive_name: "{{ ovos_virtualenv_rust_messagebu
 ovos_virtualenv_rust_messagebus_archive_url: >-
   {{ ovos_virtualenv_rust_messagebus_repo }}/releases/download/{{ ovos_virtualenv_rust_messagebus_version }}/{{ ovos_virtualenv_rust_messagebus_archive_name }}
 ovos_virtualenv_rust_messagebus_archive_checksums:
-  ovos_messagebus-aarch64-apple-darwin.tar.gz: 405d4328ade33fb88fcde009edadfd28dc7af583ba16dc77673c70a58990c7c2
-  ovos_messagebus-aarch64-unknown-linux-gnu.tar.gz: 2468ef6c1fdb27566dc92ebb0e9d92a9b804b808c590cc863e128fab70790a47
-  ovos_messagebus-arm-unknown-linux-gnueabihf.tar.gz: ed72b4ef9cea3bb23d8b73178c35a0f2c6df335c3af533d77a76c3650ecfefc3
-  ovos_messagebus-armv7-unknown-linux-gnueabihf.tar.gz: 6a9000ffebce7419bac606f7391ce15dce4d77af50800530d4eb96174e310d68
-  ovos_messagebus-x86_64-apple-darwin.tar.gz: c44d311fd62d5172001513050e3f1797625ada1d6c2fad0e6758c28644b1b5d3
-  ovos_messagebus-x86_64-unknown-linux-gnu.tar.gz: b1e668eba19be0b8c01ae1b8f6116b2a56cc823f441f6fdba1121b5b6374191d
+  ovos_messagebus-aarch64-apple-darwin.tar.gz: 7a84b1e0e2d2bbbe78e0474063ee2bdcb72125d3f21e4c570042c91db7c64700
+  ovos_messagebus-aarch64-unknown-linux-gnu.tar.gz: 8fe4bb3cad020c21a3a0b436527c85dd635b0e1a1b5984cb3afb8f279f5d4872
+  ovos_messagebus-arm-unknown-linux-gnueabihf.tar.gz: 30041a48df065a1dfeeb35369c4ef15b3615220d5203360a0fde862523f122e7
+  ovos_messagebus-armv7-unknown-linux-gnueabihf.tar.gz: 1e6f088e64c6675c1b2393bfdc62d67704509458b9aec7249b26f209b4b2604c
+  ovos_messagebus-x86_64-apple-darwin.tar.gz: e2a229e241c757bdc3f854e33943de9db787beb90f6c39d88c22ee8fcedf0939
+  ovos_messagebus-x86_64-unknown-linux-gnu.tar.gz: 63b8df5cd1a8666dc0c89a69ceabf9c435a3641c9e9cf9f5a519a615b9e64cfa
 ovos_virtualenv_rust_messagebus_archive_checksum_value: >-
   {{ ovos_virtualenv_rust_messagebus_archive_checksums[ovos_virtualenv_rust_messagebus_archive_name] | default('') }}
 ovos_virtualenv_rust_messagebus_archive_checksum: >-

--- a/tests/bats/code_quality.bats
+++ b/tests/bats/code_quality.bats
@@ -474,6 +474,9 @@ function setup() {
 }
 
 @test "rust_messagebus_download_uses_checksum_verification" {
+    run grep -q "ovos_virtualenv_rust_messagebus_version: v2.0.0" ansible/roles/ovos_virtualenv/defaults/main.yml
+    assert_success
+
     run grep -q "ovos_virtualenv_rust_messagebus_archive_checksum" ansible/roles/ovos_virtualenv/defaults/main.yml
     assert_success
 


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for additional processor architectures (armv7 and arm variants).

* **Chores**
  * Updated Rust messagebus component to v2.0.0 with corresponding integrity verification updates.

* **Tests**
  * Enhanced test coverage for version verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->