### PR TITLE
Install configured VAD plugins explicitly

### DIFF
--- a/ansible/roles/ovos_virtualenv/templates/virtualenv/core-requirements.txt.j2
+++ b/ansible/roles/ovos_virtualenv/templates/virtualenv/core-requirements.txt.j2
@@ -4,6 +4,13 @@
 ovos-audio[extras]
 ovos-core[lgpl,plugins]
 ovos-dinkum-listener[{{ 'extras' if ansible_facts.system == 'Darwin' else 'extras,linux' }}]
+# Keep configured VAD selection and Linux fallback installed explicitly.
+{% if (ovos_installer_cpu_is_capable | default(false)) | bool %}
+ovos-vad-plugin-silero
+{% endif %}
+{% if ansible_facts.system != 'Darwin' %}
+ovos-vad-plugin-webrtcvad
+{% endif %}
 {% if ansible_facts.system == 'Darwin' or _ovos_is_mark2_family %}
 ovos-microphone-plugin-sounddevice
 {% endif %}

--- a/ansible/roles/ovos_virtualenv/templates/virtualenv/satellite-requirements.txt.j2
+++ b/ansible/roles/ovos_virtualenv/templates/virtualenv/satellite-requirements.txt.j2
@@ -4,6 +4,13 @@ hivemind-bus-client
 hivemind-voice-sat
 ovos-audio[extras]
 ovos-dinkum-listener[{{ 'extras' if ansible_facts.system == 'Darwin' else 'extras,linux' }}]
+# Keep configured VAD selection and Linux fallback installed explicitly.
+{% if (ovos_installer_cpu_is_capable | default(false)) | bool %}
+ovos-vad-plugin-silero
+{% endif %}
+{% if ansible_facts.system != 'Darwin' %}
+ovos-vad-plugin-webrtcvad
+{% endif %}
 {% if ansible_facts.system == 'Darwin' or _ovos_is_mark2_family %}
 ovos-microphone-plugin-sounddevice
 {% endif %}

--- a/tests/bats/code_quality.bats
+++ b/tests/bats/code_quality.bats
@@ -1968,6 +1968,27 @@ function setup() {
     assert_success
 }
 
+@test "virtualenv_requirements_explicitly_install_configured_vad_plugins" {
+    local core_file="ansible/roles/ovos_virtualenv/templates/virtualenv/core-requirements.txt.j2"
+    local satellite_file="ansible/roles/ovos_virtualenv/templates/virtualenv/satellite-requirements.txt.j2"
+    local conf_file="ansible/roles/ovos_config/templates/mycroft.conf.j2"
+
+    run grep -F -q 'ovos-vad-plugin-silero' "$core_file"
+    assert_success
+
+    run grep -F -q 'ovos-vad-plugin-webrtcvad' "$core_file"
+    assert_success
+
+    run grep -F -q 'ovos-vad-plugin-silero' "$satellite_file"
+    assert_success
+
+    run grep -F -q 'ovos-vad-plugin-webrtcvad' "$satellite_file"
+    assert_success
+
+    run grep -F -q '"module": "{{ '\''ovos-vad-plugin-silero'\'' if (ovos_installer_cpu_is_capable | default(false)) | bool else '\''ovos-vad-plugin-webrtcvad'\'' }}"' "$conf_file"
+    assert_success
+}
+
 @test "installer_detects_and_passes_hardware_model" {
     run grep -q "detect_hardware_model" setup.sh
     assert_success


### PR DESCRIPTION
## Summary
- install the configured Silero VAD package explicitly instead of relying on a transitive extra
- install the Linux WebRTC VAD fallback package explicitly for the listener fallback chain
- add a regression guard that keeps the VAD requirements aligned with the generated config

## Problem
Issue #515 reports fresh installs where `mycroft.conf` points at `ovos-vad-plugin-silero`, but the environment does not end up with a usable VAD plugin. The installer config already selects specific VAD plugin ids, so relying only on transitive `ovos-dinkum-listener[extras]` dependencies is too weak.

## Validation
- `bats tests/bats/code_quality.bats --filter 'macos_precise_onnx_is_cpu_guarded_in_requirements|virtualenv_requirements_explicitly_install_configured_vad_plugins'`
- `uv pip install` sanity check in a fresh Python 3.11 venv with current `testing` constraints, confirming `find_plugins(PluginTypes.VAD)` resolves Silero


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Voice Activity Detection plugins now install conditionally based on system CPU capabilities and operating system type, enabling optimized performance and configuration across different hardware platforms.

* **Tests**
  * Added test suite to validate Voice Activity Detection plugin configuration and installation across core and satellite system profiles, ensuring proper setup per system specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->