### PR TITLE
Install macOS brightness formula

### DIFF
--- a/ansible/roles/ovos_virtualenv/defaults/main.yml
+++ b/ansible/roles/ovos_virtualenv/defaults/main.yml
@@ -196,6 +196,7 @@ ovos_virtualenv_macos_packages:
   - icu4c
   - jpeg-turbo
   - espeak-ng
+  - brightness
 ovos_virtualenv_gui_packages_debian:
   - cmake
   - gettext

--- a/tests/bats/code_quality.bats
+++ b/tests/bats/code_quality.bats
@@ -538,7 +538,7 @@ function setup() {
 }
 
 @test "macos_homebrew_installs_brightness_formula" {
-    run grep -q -- "- brightness" ansible/roles/ovos_virtualenv/defaults/main.yml
+    run grep -Eq -- '^[[:space:]]*-[[:space:]]*brightness[[:space:]]*$' ansible/roles/ovos_virtualenv/defaults/main.yml
     assert_success
 }
 

--- a/tests/bats/code_quality.bats
+++ b/tests/bats/code_quality.bats
@@ -537,6 +537,11 @@ function setup() {
     assert_failure
 }
 
+@test "macos_homebrew_installs_brightness_formula" {
+    run grep -q -- "- brightness" ansible/roles/ovos_virtualenv/defaults/main.yml
+    assert_success
+}
+
 @test "macos_fann_build_env_is_exported_for_uv_install" {
     run grep -q "ovos_virtualenv_macos_fann_linker_flags" ansible/roles/ovos_virtualenv/defaults/main.yml
     assert_success


### PR DESCRIPTION
## Summary

- Add the Homebrew `brightness` formula to the macOS virtualenv package list.
- Add a Bats guard to keep the formula in the macOS package set.

## Why

`ovos_phal_plugin_mac` warns that macOS brightness control requires the optional `brightness` CLI. Installing it with the rest of the macOS runtime packages lets PHAL brightness handling work without a manual `brew install brightness` step.

Fixes #526.

## Validation

- `bats tests/bats/code_quality.bats --filter 'macos_homebrew'`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added brightness package support to macOS installation dependencies
  * Added validation tests for macOS dependency configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->