### PR TITLE
Document macOS zsh and Bash runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,11 @@ macOS installs use `launchd` service management and are currently supported with
 Prerequisites:
 
 - Homebrew installed and available in `PATH`.
+- Bash 4+ installed with Homebrew (`brew install bash`) for the installer runtime.
 - Xcode Command Line Tools installed (`xcode-select --install`).
 - Microphone permission granted to your terminal app (System Settings > Privacy & Security > Microphone).
 
-The installer also deploys a zsh wrapper (`~/.config/ovos-installer/ovos-launchd.zsh`) and sources it from `~/.zshrc` so you can manage launchd services with `ovos ...` commands.
+Your login shell can remain zsh. The installer also deploys a zsh wrapper (`~/.config/ovos-installer/ovos-launchd.zsh`) and sources it from `~/.zshrc` so you can manage launchd services with `ovos ...` commands.
 
 ## 🐧 Supported Linux distributions
 


### PR DESCRIPTION
## Summary

Clarify the macOS README prerequisites around zsh and Bash:

- document that Bash 4+ from Homebrew is required for the installer runtime
- clarify that the user's login shell can remain zsh
- keep the existing note about the installed zsh launchd wrapper

## Why

Issue #519 asks for zsh support on macOS because the installer requires Bash >= 4. The repo already supports zsh for the post-install launchd helper, while the installer scripts still require Bash 4+ features. This docs change makes that distinction explicit.

Closes #519.

## Validation

Docs-only change; no runtime tests run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated macOS prerequisites to explicitly require Bash 4+ installed via Homebrew
  * Clarified that login shell can remain zsh; installer deploys zsh wrapper sourced from `~/.zshrc` for service management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->