### PR TITLE
Disable ggwave by default

### DIFF
--- a/ansible/roles/ovos_installer/defaults/main.yml
+++ b/ansible/roles/ovos_installer/defaults/main.yml
@@ -79,13 +79,10 @@ ovos_installer_supported_desktop_architectures:
   - x86_64
   - aarch64
   - arm64
-# ggwave stack doesn't support the ovos-audio >=1.1 move to plugin-manager >=2 yet,
-# and macOS often requires source builds for ggwave dependencies, so keep it
-# disabled there by default until dedicated Darwin packaging is available.
-ovos_installer_enable_ggwave: >-
-  {{ ansible_facts.system != 'Darwin'
-     and (ovos_installer_channel | default('')) == 'testing'
-     and ansible_facts.architecture in ovos_installer_supported_desktop_architectures }}
+# ggwave still depends on the plugin-manager 1.x stack, while the current
+# OVOS testing stack resolves to plugin-manager 2.x. Keep it opt-in until
+# ovos-audio-transformer-plugin-ggwave is compatible with plugin-manager 2.x.
+ovos_installer_enable_ggwave: false
 ovos_installer_uv_allow_prerelease: "{{ (ovos_installer_venv_python_major | int) == 3 and (ovos_installer_venv_python_minor | int) >= 13 }}"
 ovos_installer_tuning: false
 ovos_installer_setuptools_package: "setuptools<82"

--- a/tests/bats/code_quality.bats
+++ b/tests/bats/code_quality.bats
@@ -775,6 +775,13 @@ function setup() {
     assert_success
 }
 
+@test "ggwave_is_disabled_by_default" {
+    local defaults_file="ansible/roles/ovos_installer/defaults/main.yml"
+
+    run grep -q "^ovos_installer_enable_ggwave: false$" "$defaults_file"
+    assert_success
+}
+
 @test "virtualenv_repairs_ownership_before_python_package_installs" {
     local defaults_file="ansible/roles/ovos_virtualenv/defaults/main.yml"
     local file="ansible/roles/ovos_virtualenv/tasks/venv.yml"


### PR DESCRIPTION
ggwave is pulling us back onto the plugin-manager 1.x stack, then later venv install passes can move plugin-manager to 2.x and leave the old VAD entry points behind. That is what makes Silero look installed but not loadable.

This keeps ggwave opt-in for now, until ovos-audio-transformer-plugin-ggwave is updated for plugin-manager 2.x.

Fixes #533

Related:
- #528

Tested with:

```bash
bats tests/bats/code_quality.bats
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Configuration**
  * Ggwave is now disabled by default, replacing the previous conditional enablement behavior. Users who rely on this feature may need to manually re-enable it.

* **Tests**
  * Added test verification for the new default configuration setting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenVoiceOS/ovos-installer/pull/534)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->