### PR TITLE
Add MK2 v6 fan control plugin for DevKit builds. fix #536

### DIFF
--- a/ansible/roles/ovos_config/templates/mycroft.conf.j2
+++ b/ansible/roles/ovos_config/templates/mycroft.conf.j2
@@ -8,10 +8,10 @@
 {% endif %}
 {% set _ovos_is_raspberry_pi_4 = (ovos_installer_raspberrypi | default('')) | regex_search(ovos_installer_raspberry_pi_4_regex) %}
 {% set _ovos_is_mark2_family = _ovos_is_raspberry_pi_4 and ('tas5806' in (ovos_installer_i2c_devices | default([]))) %}
+{% set _ovos_is_devkit = _ovos_is_mark2_family and ('attiny1614' in (ovos_installer_i2c_devices | default([]))) %}
 {% if ovos_installer_profile != "server" %}
 {% set _ovos_is_macos = (ansible_facts.system | default('')) == 'Darwin' %}
 {% set _ovos_is_mark2 = _ovos_is_mark2_family and ('attiny1614' not in (ovos_installer_i2c_devices | default([]))) %}
-{% set _ovos_is_devkit = _ovos_is_mark2_family and ('attiny1614' in (ovos_installer_i2c_devices | default([]))) %}
 {% set _ovos_use_sounddevice_mic = _ovos_is_macos or _ovos_is_mark2_family %}
 {% set _ovos_listener_has_wake_word = (_ovos_is_macos and ((ovos_installer_cpu_is_capable | default(false)) | bool)) or (ovos_installer_tuning | bool) %}
 {% set _ovos_hotword_sensitivity = ovos_config_mark2_hotword_sensitivity if _ovos_is_mark2 else ovos_config_hotword_sensitivity %}

--- a/ansible/roles/ovos_config/templates/mycroft.conf.j2
+++ b/ansible/roles/ovos_config/templates/mycroft.conf.j2
@@ -11,6 +11,7 @@
 {% if ovos_installer_profile != "server" %}
 {% set _ovos_is_macos = (ansible_facts.system | default('')) == 'Darwin' %}
 {% set _ovos_is_mark2 = _ovos_is_mark2_family and ('attiny1614' not in (ovos_installer_i2c_devices | default([]))) %}
+{% set _ovos_is_devkit = _ovos_is_mark2_family and ('attiny1614' in (ovos_installer_i2c_devices | default([]))) %}
 {% set _ovos_use_sounddevice_mic = _ovos_is_macos or _ovos_is_mark2_family %}
 {% set _ovos_listener_has_wake_word = (_ovos_is_macos and ((ovos_installer_cpu_is_capable | default(false)) | bool)) or (ovos_installer_tuning | bool) %}
 {% set _ovos_hotword_sensitivity = ovos_config_mark2_hotword_sensitivity if _ovos_is_mark2 else ovos_config_hotword_sensitivity %}
@@ -162,7 +163,12 @@
     },
     "ovos-phal-plugin-ipgeo": {
       "enabled": true
+    }{{ ',' if _ovos_is_devkit else '' }}
+{% if _ovos_is_devkit %}
+    "ovos-PHAL-plugin-mk2-v6-fan-control": {
+      "enabled": true
     }
+{% endif %}
 {% endif %}
   }{% if ovos_installer_usage_telemetry| bool %},
   "open_data": {


### PR DESCRIPTION
- Introduce _ovos_is_devkit variable for Mark2 family with attiny1614
- Conditionally enable ovos-PHAL-plugin-mk2-v6-fan-control for DevKit
- Fix #536 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic fan control support for Mark2 v6 devices when hardware is detected on compatible systems.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenVoiceOS/ovos-installer/pull/537?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->