### PR TITLE
Fix Docker repository cache refresh

### DIFF
--- a/ansible/roles/ovos_containers/tasks/setup-Debian.yml
+++ b/ansible/roles/ovos_containers/tasks/setup-Debian.yml
@@ -44,7 +44,7 @@
       {{ ovos_containers_docker_repo_base_url }}/{{ ovos_containers_os_distribution }}
       {{ release }} {{ ovos_containers_docker_repo_channel }}
     filename: "{{ ovos_containers_docker_repo_apt_filename }}"
-    update_cache: false
+    update_cache: true
 
 - name: Install Docker Engine
   ansible.builtin.apt:


### PR DESCRIPTION
## Summary

- refresh the APT package index when the Docker repository is added or changed
- retain the one-hour cache window on the Docker package installation task

## Root cause

The Docker repository task disabled cache updates. The following package task requested an update but also accepted a cache up to one hour old, so a recent update performed before the Docker source was added could prevent the new repository from being indexed. Docker packages then appeared unavailable until a later `apt-get update`.

## Impact

Fresh Debian and Ubuntu container installations can resolve `docker-ce` immediately after adding Docker's repository, while repeat runs still avoid unnecessary cache refreshes.

## Validation

- `ANSIBLE_CONFIG=../ansible.cfg ansible-lint`
- `yamllint -c ansible/.yamllint ansible/roles/ovos_containers/tasks/setup-Debian.yml`
- containers playbook `ansible-playbook --syntax-check`
- `git diff --check`

Fixes #554


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Docker package repository setup by ensuring the local package cache is refreshed during installation.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->