### PR TITLE
docs: rewrite README in Simplified Technical English

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,28 @@
-# 🎉 Open Voice OS and HiveMind Installer 🎉
+# Open Voice OS and HiveMind Installer
 
-Installer for Open Voice OS (OVOS) and HiveMind on Linux and macOS. Supports interactive installs, scenario-based automation, and optional container deployment.
+This installer sets up Open Voice OS (OVOS) and HiveMind on Linux and macOS. It supports interactive installs, scenario-based automation, and optional container deployment.
 
-## 🤖 What is Open Voice OS?
+## What is Open Voice OS?
 
 Open Voice OS (OVOS) is an open-source voice assistant platform focused on privacy and customization. HiveMind extends OVOS with distributed voice processing across multiple devices.
 
-## 🚀 Quickstart
+## Quickstart
 
-Prereqs: `curl`, `git`, and `sudo`. Run:
+The installer needs `curl`, `git`, and `sudo`. Run:
 
 ```shell
 sudo sh -c "$(curl -fsSL https://raw.githubusercontent.com/OpenVoiceOS/ovos-installer/main/installer.sh)"
 ```
 
-If you prefer to inspect before running, download the script first, review it, then execute it with `sudo sh installer.sh`.
+If you prefer to inspect the script before you run it, download it first, review it, then run it with `sudo sh installer.sh`.
 
-This downloads and runs the installer interactively.
+This command downloads and runs the installer interactively.
 
-> Heads-up: OVOS targets a supported Python runtime in its virtualenv (default `3.11`). The installer uses `uv` to provision that version if it is not already available. You can override with `OVOS_VENV_PYTHON` if you want to use a different version that is available on your system.
+Note: OVOS targets a supported Python runtime in its virtual environment (default `3.11`). The installer uses `uv` to provision that version if it is not already available. Set `OVOS_VENV_PYTHON` to use a different version that is available on your system.
 
-### ⚙️ Passing environment variables to the `curl` one-liner
+### Pass environment variables to the `curl` one-liner
 
-To set environment variables when using the `curl` one-liner, use `sudo env ...` so the variables are visible to the installer:
+To set environment variables when you use the `curl` one-liner, use `sudo env ...` so the variables reach the installer:
 
 ```shell
 # Enable debug logs (adds bash -x and increases Ansible verbosity)
@@ -38,27 +38,27 @@ sudo env REUSE_CACHED_ARTIFACTS=true sh -c "$(curl -fsSL https://raw.githubuserc
 sudo env HTTPS_PROXY=http://proxy.example:3128 HTTP_PROXY=http://proxy.example:3128 NO_PROXY=localhost,127.0.0.1 sh -c "$(curl -fsSL https://raw.githubusercontent.com/OpenVoiceOS/ovos-installer/main/installer.sh)"
 ```
 
-👉 Guide: [Howto - Begin your Open Voice OS journey with the OVOS installer](https://community.openconversational.ai/t/howto-begin-your-open-voice-os-journey-with-the-ovos-installer/14900)
+Guide: [Howto - Begin your Open Voice OS journey with the OVOS installer](https://community.openconversational.ai/t/howto-begin-your-open-voice-os-journey-with-the-ovos-installer/14900)
 
-## 🍎 macOS support (Intel + Apple Silicon)
+## macOS support (Intel and Apple Silicon)
 
-macOS installs use `launchd` service management and are currently supported with this matrix only:
+macOS installs use `launchd` for service management. This matrix is the only one currently supported on macOS:
 
 - `method: virtualenv`
 - `channel: alpha`
 
 Prerequisites:
 
-- Homebrew installed and available in `PATH`.
-- Bash 4+ installed with Homebrew (`brew install bash`) for the installer runtime.
-- Xcode Command Line Tools installed (`xcode-select --install`).
+- Homebrew, installed and available in `PATH`.
+- Bash 4 or later, installed with Homebrew (`brew install bash`), for the installer runtime.
+- Xcode Command Line Tools (`xcode-select --install`).
 - Microphone permission granted to your terminal app (System Settings > Privacy & Security > Microphone).
 
-Your login shell can remain zsh. The installer also deploys a zsh wrapper (`~/.config/ovos-installer/ovos-launchd.zsh`) and sources it from `~/.zshrc` so you can manage launchd services with `ovos ...` commands.
+Your login shell can stay zsh. The installer also deploys a zsh wrapper (`~/.config/ovos-installer/ovos-launchd.zsh`) and sources it from `~/.zshrc`, so you can manage launchd services with `ovos ...` commands.
 
-## 🐧 Supported Linux distributions
+## Supported Linux distributions
 
-The installer has been tested on the following Linux distributions and versions:
+The installer has been tested on these Linux distributions and versions:
 
 | Distribution        | Version   |
 | ------------------- | --------- |
@@ -83,15 +83,15 @@ The installer has been tested on the following Linux distributions and versions:
 | WSL2                | `20.04`   |
 | Zorin OS            | `>= 16`   |
 
-Note: 'rolling' indicates a rolling release distribution with no fixed version number. Role metadata in `ansible/roles/*/meta/main.yml` lists the base OS families/versions (e.g., Debian/Ubuntu/EL/Fedora/Arch/Suse) that cover these distributions.
+`rolling` means a rolling-release distribution with no fixed version number. Role metadata in `ansible/roles/*/meta/main.yml` lists the base OS families and versions (Debian/Ubuntu/EL/Fedora/Arch/Suse) that cover these distributions.
 
-## 🔄 Update
+## Update
 
-To update, optionally back up your configuration (`~/.config/mycroft/mycroft.conf` or `~/ovos/config/mycroft.conf`) and re-run the installer. When prompted, answer **"No"** to _"Do you want to uninstall Open Voice OS?"_.
+To update, back up your configuration if you want to keep it (`~/.config/mycroft/mycroft.conf` or `~/ovos/config/mycroft.conf`), then re-run the installer. When the installer asks "Do you want to uninstall Open Voice OS?", answer **"No"**.
 
-## ⚙️ Service management
+## Service management
 
-### 🍎 macOS (launchd wrapper)
+### macOS (launchd wrapper)
 
 Use the `ovos` wrapper command:
 
@@ -112,11 +112,11 @@ ovos list
 
 `ovos` is a meta target for all installed OVOS user services on macOS.
 
-### 🐧 Linux (systemd)
+### Linux (systemd)
 
-When the `virtualenv` method is chosen (default), systemd unit files are created to manage OVOS services. Some installs run services in system scope for performance/realtime tuning; use the matching commands below.
+When the `virtualenv` method is chosen (the default), the installer creates systemd unit files to manage OVOS services. Some installs run services in system scope for performance or realtime tuning; use the matching commands below.
 
-### 📋 List the systemd unit files
+### List the systemd unit files
 
 User scope (default):
 
@@ -132,7 +132,7 @@ sudo systemctl list-units "*ovos*"
 
 `ovos-phal-admin` always runs as `root`. The main `ovos` service runs in user or system scope depending on your install.
 
-### 🟢 Start Open Voice OS
+### Start Open Voice OS
 
 User scope (default):
 
@@ -148,7 +148,7 @@ sudo systemctl start ovos
 sudo systemctl start ovos-phal-admin
 ```
 
-### 🔴 Stop Open Voice OS
+### Stop Open Voice OS
 
 User scope (default):
 
@@ -164,7 +164,7 @@ sudo systemctl stop ovos
 sudo systemctl stop ovos-phal-admin
 ```
 
-## 🎙️ Audio calibration tool
+## Audio calibration tool
 
 If wake word detection is weak or inconsistent, run the calibration helper to tune your microphone input. The tool records short samples (silence, speech, wake word), measures signal levels, and recommends capture volume and listener multiplier values.
 
@@ -178,13 +178,13 @@ To apply the recommended capture volume automatically:
 scripts/audio-calibrate.sh --apply
 ```
 
-Bluetooth headsets work too, but the mic typically needs the HFP/HSP profile. The installer will attempt to switch profiles automatically when a Bluetooth mic is the default input.
+Bluetooth headsets work too, but the microphone typically needs the HFP/HSP profile. The installer attempts to switch profiles automatically when a Bluetooth microphone is the default input.
 
-## 🤖 Automated install
+## Automated install
 
-The installer supports non-interactive installation via a scenario file at `~/.config/ovos-installer/scenario.yaml`. This is useful for scripting or deploying to multiple devices.
+The installer supports non-interactive installation through a scenario file at `~/.config/ovos-installer/scenario.yaml`. Use this to script installs or deploy to multiple devices.
 
-Here is an example of a scenario to install Open Voice OS within Docker containers on a Raspberry Pi 4B with default skills.
+This example scenario installs Open Voice OS in Docker containers on a Raspberry Pi 4B with default skills:
 
 ```shell
 mkdir -p ~/.config/ovos-installer
@@ -206,9 +206,9 @@ EOF
 ### Configuration options explained
 
 - `uninstall`: Set to `true` to uninstall instead of install.
-- `method`: Installation method (`containers` for Docker, `virtualenv` for Python virtual environment). On macOS and Mark 2 hardware, use `virtualenv` only.
+- `method`: Installation method (`containers` for Docker, `virtualenv` for a Python virtual environment). On macOS and Mark 2 hardware, use `virtualenv` only.
 - `channel`: Release channel (`testing`, `alpha`). On macOS, use `alpha` only.
-- `profile`: Installation profile (`ovos` for standard setup).
+- `profile`: Installation profile (`ovos` for a standard setup).
 - `features.skills`: Install default voice skills.
 - `features.extra_skills`: Install additional community skills.
 - `features.llm`: Enable OVOS Persona LLM fallback.
@@ -220,29 +220,29 @@ EOF
 - `share_telemetry`: Allow sharing anonymous usage statistics.
 - `share_usage_telemetry`: Allow sharing detailed usage data.
 
-Example scenarios live in the [scenarios](https://github.com/OpenVoiceOS/ovos-installer/tree/main/scenarios) directory of this repository.
+Example scenarios live in the [scenarios](https://github.com/OpenVoiceOS/ovos-installer/tree/main/scenarios) directory of this repository. See [docs/telemetry.md](docs/telemetry.md) for what the telemetry options send.
 
-## 🧩 Ansible role map
+## Ansible role map
 
 The installer is modular. The top-level wrapper role (`ovos_installer`) orchestrates focused roles, roughly in this order:
 
-- `ovos_facts`: Shared installer facts (boot dir, NetworkManager, systemd paths)
+- `ovos_facts`: Shared installer facts (boot directory, NetworkManager, systemd paths)
 - `ovos_timezone`: Detect and configure system timezone
 - `ovos_config`: Configuration defaults and `mycroft.conf` generation
 - `ovos_sound`: Sound server setup (PipeWire/PulseAudio)
-- `ovos_virtualenv`: Python virtualenv provisioning and package install
+- `ovos_virtualenv`: Python virtual environment provisioning and package install
 - `ovos_containers`: Docker/compose provisioning and deployment
-- `ovos_services`: Systemd units + handlers (user or system scope)
+- `ovos_services`: Systemd units and handlers (user or system scope)
 - `ovos_telemetry`: Optional telemetry submission
 - `ovos_storage_tuning`: fstab/log2ram/tmpfs tuning
 - `ovos_audio_tuning`: PipeWire/WirePlumber tuning
 - `ovos_python`: Python runtime tuning (mimalloc, env)
 - `ovos_performance_tuning`: governor, I/O, zram, sysctl, NUMA, limits
-- `ovos_network_tuning`: wireless power + DNS caching
+- `ovos_network_tuning`: wireless power and DNS caching
 - `ovos_finalize`: Post-install cleanup and drift notice
 - `ovos_hardware_mark1` / `ovos_hardware_mark2`: hardware-specific roles (applied when detected)
 
-## ❌ Uninstall
+## Uninstall
 
 Uninstalling Open Voice OS removes installed components, configurations, and services. Back up any important data first.
 
@@ -254,7 +254,13 @@ sudo sh -c "$(curl -fsSL https://raw.githubusercontent.com/OpenVoiceOS/ovos-inst
 sudo env DEBUG=true sh -c "$(curl -fsSL https://raw.githubusercontent.com/OpenVoiceOS/ovos-installer/main/installer.sh)" installer.sh --uninstall
 ```
 
-## 🖼️ Screenshots
+## Related projects
+
+- [OpenVoiceOS/ovos-core](https://github.com/OpenVoiceOS/ovos-core) — the OVOS assistant core this installer sets up.
+- [JarbasHiveMind/HiveMind-core](https://github.com/JarbasHiveMind/HiveMind-core) — the HiveMind server this installer can also set up.
+- [OpenVoiceOS/raspOVOS](https://github.com/OpenVoiceOS/raspOVOS) — a prebuilt Raspberry Pi image for OVOS.
+
+## Screenshots
 
 ![Screenshot 1](docs/images/screenshot_1.png)
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Open Voice OS (OVOS) is an open-source voice assistant platform focused on priva
 
 ## Quickstart
 
-The installer needs `curl`, `git`, and `sudo`. Run:
+The installer needs `curl`, `git`, `sudo`, and Bash 4 or later. Run:
 
 ```shell
 sudo sh -c "$(curl -fsSL https://raw.githubusercontent.com/OpenVoiceOS/ovos-installer/main/installer.sh)"
@@ -38,7 +38,7 @@ sudo env REUSE_CACHED_ARTIFACTS=true sh -c "$(curl -fsSL https://raw.githubuserc
 sudo env HTTPS_PROXY=http://proxy.example:3128 HTTP_PROXY=http://proxy.example:3128 NO_PROXY=localhost,127.0.0.1 sh -c "$(curl -fsSL https://raw.githubusercontent.com/OpenVoiceOS/ovos-installer/main/installer.sh)"
 ```
 
-Guide: [Howto - Begin your Open Voice OS journey with the OVOS installer](https://community.openconversational.ai/t/howto-begin-your-open-voice-os-journey-with-the-ovos-installer/14900)
+Guide: [Begin your Open Voice OS journey with the OVOS installer](https://community.openconversational.ai/t/howto-begin-your-open-voice-os-journey-with-the-ovos-installer/14900)
 
 ## macOS support (Intel and Apple Silicon)
 
@@ -116,7 +116,7 @@ ovos list
 
 When the `virtualenv` method is chosen (the default), the installer creates systemd unit files to manage OVOS services. Some installs run services in system scope for performance or realtime tuning; use the matching commands below.
 
-### List the systemd unit files
+### List the systemd units
 
 User scope (default):
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -1,40 +1,41 @@
 # Open Voice OS installer telemetry
 
-One of the many ways to improve software is to know how users utilize it; to get this information, some data must be shared from the user to the developers.
+Usage data helps improve software. To get this data, some information passes from the user to the developers.
 
-The installer collects anonymous data and sends it to Open Voice OS servers to help improve Open Voice OS, none of them be used for commercial purpose.
+The installer collects anonymous data and sends it to Open Voice OS servers to help improve Open Voice OS. None of it is used for commercial purposes.
 
-The data collection only happens during the installation process, nothing else will be collected once the installation is over.
+Data collection happens only during the installation process. Nothing else is collected once the installation ends.
 
-**The installer will ask you if you want to share or not the data.**
+**The installer asks you whether you want to share the data.**
 
-Below is a list of the collected data _(see the [Ansible task](https://github.com/OpenVoiceOS/ovos-installer/blob/main/ansible/roles/ovos_telemetry/tasks/main.yml) that builds and sends the telemetry payload)_.
+The table below lists the collected data. See the [Ansible task](https://github.com/OpenVoiceOS/ovos-installer/blob/main/ansible/roles/ovos_telemetry/tasks/main.yml) that builds and sends the telemetry payload.
 
-| Data                   | Description                                              |
-| ---------------------- | -------------------------------------------------------- |
-| `architecture`         | CPU architecture where OVOS was installed                |
-| `channel`              | `testing` or `alpha` version of OVOS                     |
-| `container`            | OVOS installed into containers                           |
-| `country`              | Country where OVOS has been installed                    |
-| `cpu_capable`          | Is the CPU supports AVX2 or SIMD instructions            |
-| `display_server`       | Is X or Wayland are used as display server               |
-| `extra_skills_feature` | Extra OVOS's skills enabled during the installation      |
-| `gui_feature`          | GUI enabled during the installation                      |
-| `hardware`             | Is the device a Mark 1, Mark II or DevKit                |
+| Data                    | Description                                             |
+| ----------------------- | -------------------------------------------------------- |
+| `architecture`          | CPU architecture where OVOS was installed                |
+| `channel`               | `testing` or `alpha` version of OVOS                     |
+| `container`             | OVOS installed into containers                           |
+| `country`               | Country where OVOS was installed                          |
+| `cpu_capable`           | Whether the CPU supports AVX2 or SIMD instructions        |
+| `display_server`        | Whether X or Wayland is used as the display server         |
+| `extra_skills_feature`  | Extra OVOS skills enabled during the installation         |
+| `gui_feature`           | GUI enabled during the installation                       |
+| `hardware`              | Whether the device is a Mark 1, Mark II, or DevKit          |
 | `homeassistant_feature` | Home Assistant feature enabled during the installation    |
-| `llm_feature`           | LLM feature enabled during the installation               |
-| `installed_at`         | Date when OVOS has been installed                        |
-| `os_kernel`            | Kernel version of the host where OVOS is running         |
-| `os_name`              | OS name of the host where OVOS is running                |
-| `os_type`              | OS type of the host where OVOS is running                |
-| `os_version`           | OS version of the host where OVOS is running             |
-| `profile`              | Which profile has been used during the OVOS installation |
-| `python_version`       | What Python version was running on the host              |
-| `raspberry_pi`         | Does OVOS has been installed on Raspberry Pi             |
-| `skills_feature`       | Default OVOS's skills enabled during the installation    |
-| `sound_server`         | What PulseAudio or PipeWire used                         |
-| `tuning_enabled`       | Did the Raspberry Pi tuning feature was used             |
-| `venv`                 | OVOS installed into a Python virtual environment         |
+| `llm_feature`           | LLM feature enabled during the installation                |
+| `installed_at`          | Date when OVOS was installed                              |
+| `os_kernel`             | Kernel version of the host running OVOS                   |
+| `os_name`               | OS name of the host running OVOS                          |
+| `os_type`               | OS type of the host running OVOS                           |
+| `os_version`            | OS version of the host running OVOS                        |
+| `profile`               | Profile used during the OVOS installation                 |
+| `python_version`        | Python version running on the host                        |
+| `raspberry_pi`          | Whether OVOS was installed on a Raspberry Pi                |
+| `skills_feature`        | Default OVOS skills enabled during the installation        |
+| `sound_server`          | Whether PulseAudio or PipeWire is used                     |
+| `tuning_enabled`        | Whether the Raspberry Pi tuning feature was used            |
+| `venv`                  | OVOS installed into a Python virtual environment           |
 
-No Home Assistant URL or API key values are collected, only whether the Home Assistant feature was enabled.
-No LLM API URL, API key, model, or persona values are collected, only whether the LLM feature was enabled.
+No Home Assistant URL or API key value is collected, only whether the Home Assistant feature was enabled.
+
+No LLM API URL, API key, model, or persona value is collected, only whether the LLM feature was enabled.

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -8,7 +8,7 @@ Usage data helps improve software. To get this data, some information passes fro
 
 The installer sends one payload to `https://telemetry.smartgic.io/ovos-installer/metrics/` while it runs. It collects nothing after the installation ends.
 
-To fill the `country` field, the installer asks `http://ip-api.com/json` to look up the location of the host. That request tells a third-party service your IP address. Decline installer telemetry if you do not want that lookup to happen.
+To fill the `country` field, the installer asks `http://ip-api.com/json` to look up the location of the host. That request tells a third-party service your IP address, and it goes over plain HTTP, so anything on the path can read it. Decline installer telemetry if you do not want that lookup to happen.
 
 The table below lists the collected data. See the [Ansible task](https://github.com/OpenVoiceOS/ovos-installer/blob/main/ansible/roles/ovos_telemetry/tasks/main.yml) that builds and sends the telemetry payload.
 
@@ -56,7 +56,12 @@ If you accept them, the installer writes this into your `mycroft.conf`:
 }
 ```
 
-Your assistant then reports the intents it matches to that address, for as long as the setting stays in the configuration file. To stop it later, remove the `open_data` block from `~/.config/mycroft/mycroft.conf` and restart the OVOS services.
+Your assistant then reports the intents it matches to that address, for as long as the setting stays in the configuration file. To stop it later, remove the `open_data` block and restart the OVOS services. The file is in a different place for each install method:
+
+| Method | Configuration file |
+| ---------- | ------------------------------ |
+| virtualenv | `~/.config/mycroft/mycroft.conf` |
+| containers | `~/ovos/config/mycroft.conf`     |
 
 The collected data is published on the [Open Data portal](https://opendata.tigregotico.pt), where it can be viewed and downloaded.
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -2,11 +2,13 @@
 
 Usage data helps improve software. To get this data, some information passes from the user to the developers.
 
-The installer collects anonymous data and sends it to Open Voice OS servers to help improve Open Voice OS. None of it is used for commercial purposes.
+**The installer asks you separately about each of the two options below. Both are off unless you accept them.**
 
-Data collection happens only during the installation process. Nothing else is collected once the installation ends.
+## Installer telemetry
 
-**The installer asks you whether you want to share the data.**
+The installer sends one payload to `https://telemetry.smartgic.io/ovos-installer/metrics/` while it runs. It collects nothing after the installation ends.
+
+To fill the `country` field, the installer asks `http://ip-api.com/json` to look up the location of the host. That request tells a third-party service your IP address. Decline installer telemetry if you do not want that lookup to happen.
 
 The table below lists the collected data. See the [Ansible task](https://github.com/OpenVoiceOS/ovos-installer/blob/main/ansible/roles/ovos_telemetry/tasks/main.yml) that builds and sends the telemetry payload.
 
@@ -39,3 +41,23 @@ The table below lists the collected data. See the [Ansible task](https://github.
 No Home Assistant URL or API key value is collected, only whether the Home Assistant feature was enabled.
 
 No LLM API URL, API key, model, or persona value is collected, only whether the LLM feature was enabled.
+
+## Usage metrics
+
+Usage metrics are a different option, and they do not stop when the installation ends.
+
+If you accept them, the installer writes this into your `mycroft.conf`:
+
+```json
+"open_data": {
+  "intent_urls": [
+    "https://metrics.tigregotico.pt/intents"
+  ]
+}
+```
+
+Your assistant then reports the intents it matches to that address, for as long as the setting stays in the configuration file. To stop it later, remove the `open_data` block from `~/.config/mycroft/mycroft.conf` and restart the OVOS services.
+
+The collected data is published on the [Open Data portal](https://opendata.tigregotico.pt), where it can be viewed and downloaded.
+
+Both endpoints are run by the Open Voice OS community rather than by this repository, so their retention and their use of the data are documented where each service is, not here.


### PR DESCRIPTION
Rewrites README.md and docs/telemetry.md for clarity, removing emoji and marketing language while keeping every fact, code block, and link. Adds a related-projects section linking sibling org repos (ovos-core, HiveMind-core, raspOVOS).

Rewritten by Claude Sonnet 5 using the ste-writing skill (authored and reviewed by Claude Fable 5); linted with ste_lint.py.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Refreshed the README with clearer setup, configuration, macOS prerequisites, shell-wrapper behavior, updates, service management, Bluetooth calibration, telemetry, and Ansible guidance.
  * Added Python-version configuration details and a Related projects section.
  * Clarified installer telemetry, including its endpoint, consent behavior, IP-based country lookup, retention, and collected data.
  * Documented ongoing usage metrics, including configuration, reporting, opt-out instructions, publication details, and service ownership.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->