### PR TITLE
Warn when a container runtime cannot be queried for existing instances

### DIFF
--- a/tests/bats/instance.bats
+++ b/tests/bats/instance.bats
@@ -154,3 +154,79 @@ function setup() {
 function teardown() {
     rm -f "$LOG_FILE"
 }
+
+@test "function_detect_existing_instance_reports_unreachable_container_runtime" {
+    RUN_AS_HOME="$BATS_TMPDIR/testuser3"
+    function uname() {
+        if [[ "$1" == "-s" ]]; then
+            echo "Linux"
+            return 0
+        fi
+        command uname "$@"
+    }
+    function docker() {
+        # Daemon down: the CLI exists but "docker ps" fails.
+        if [[ "$1" == "ps" ]]; then
+            echo "Cannot connect to the Docker daemon" >&2
+            return 1
+        fi
+    }
+    function podman() {
+        return 0
+    }
+    export -f uname docker podman
+    detect_existing_instance
+    assert_equal "$EXISTING_INSTANCE" "false"
+    assert_equal "$CONTAINER_RUNTIME_PROBE_FAILED" "Docker"
+    unset uname docker podman
+}
+
+@test "function_detect_existing_instance_warns_when_container_runtime_is_unreachable" {
+    RUN_AS_HOME="$BATS_TMPDIR/testuser3"
+    function uname() {
+        if [[ "$1" == "-s" ]]; then
+            echo "Linux"
+            return 0
+        fi
+        command uname "$@"
+    }
+    function docker() {
+        if [[ "$1" == "ps" ]]; then
+            return 1
+        fi
+    }
+    function podman() {
+        if [[ "$1" == "ps" ]]; then
+            return 125
+        fi
+    }
+    export -f uname docker podman
+    run detect_existing_instance
+    assert_success
+    assert_output --partial "Unable to query Docker and Podman"
+    unset uname docker podman
+}
+
+@test "function_detect_existing_instance_does_not_warn_when_runtimes_answer" {
+    RUN_AS_HOME="$BATS_TMPDIR/testuser3"
+    function uname() {
+        if [[ "$1" == "-s" ]]; then
+            echo "Linux"
+            return 0
+        fi
+        command uname "$@"
+    }
+    function docker() {
+        return 0
+    }
+    function podman() {
+        return 0
+    }
+    export -f uname docker podman
+    run detect_existing_instance
+    assert_success
+    refute_output --partial "Unable to query"
+    detect_existing_instance
+    assert_equal "$CONTAINER_RUNTIME_PROBE_FAILED" ""
+    unset uname docker podman
+}

--- a/utils/common.sh
+++ b/utils/common.sh
@@ -196,6 +196,15 @@ function container_runtime_has_ovos_instance() {
     fi
 
     if [ "$runtime_status" -ne 0 ]; then
+        # The CLI is installed but the daemon did not answer, so this runtime
+        # could still be hosting an instance we are unable to see. Remember it
+        # so detect_existing_instance() can warn instead of reporting nothing.
+        if [ -n "${CONTAINER_RUNTIME_PROBE_FAILED:-}" ]; then
+            CONTAINER_RUNTIME_PROBE_FAILED="${CONTAINER_RUNTIME_PROBE_FAILED} and ${runtime_label}"
+        else
+            CONTAINER_RUNTIME_PROBE_FAILED="${runtime_label}"
+        fi
+        export CONTAINER_RUNTIME_PROBE_FAILED
         printf '%s\n' "[info] ${runtime_label} detected but daemon unavailable (${runtime_cmd} ps exit ${runtime_status})" &>>"$LOG_FILE"
     fi
 
@@ -510,6 +519,7 @@ function detect_existing_instance() {
     printf '%s' "➤ Checking for existing instance... "
     export EXISTING_INSTANCE="false"
     unset INSTANCE_TYPE || true
+    export CONTAINER_RUNTIME_PROBE_FAILED=""
     local current_system
     current_system="$(uname -s 2>>"$LOG_FILE" || true)"
     local skip_container_runtime_checks="false"
@@ -565,6 +575,13 @@ function detect_existing_instance() {
         done
     fi
     echo -e "[$done_format]"
+
+    # A runtime we could not query may still hold an instance. Staying silent
+    # here is how an install ends up layered on top of an existing one.
+    if [ -n "${CONTAINER_RUNTIME_PROBE_FAILED:-}" ]; then
+        log_warn "⚠ Unable to query ${CONTAINER_RUNTIME_PROBE_FAILED} for existing Open Voice OS containers."
+        log_warn "  An existing container instance cannot be detected while the daemon is unreachable, see ${LOG_FILE} for details."
+    fi
 }
 
 # Check is a display server is running such as X or Wayland


### PR DESCRIPTION
Follow-up to #561.

## Problem

`detect_existing_instance()` probes Docker and Podman for `ovos-*` / `hivemind-*` containers. When the CLI is installed but the daemon does not answer, `container_runtime_has_ovos_instance()` writes a line to `$LOG_FILE` and returns 1, and detection carries on as if the host were clean.

That is reachable by the user, and it is what the reporter in #561 hit: stopping the Docker service is enough to make the installer offer a virtualenv install on top of a container deployment it can no longer see. Nothing on the console says the check was incomplete.

## Change

- `container_runtime_has_ovos_instance()` records the runtime label in `CONTAINER_RUNTIME_PROBE_FAILED` when `ps -a` exits non-zero.
- `detect_existing_instance()` resets that variable at the start and, once the check is done, warns on the console when a runtime could not be reached, pointing at the installer log for the exit status.

Detection behaviour is otherwise unchanged: nothing new is blocked, and a host without Docker or Podman installed never sets the flag, so no warning appears there.

```
➤ Checking for existing instance... done
⚠ Unable to query Docker for existing Open Voice OS containers.
  An existing container instance cannot be detected while the daemon is unreachable, see /var/log/ovos-installer.log for details.
```

## Tests

Three cases added to `tests/bats/instance.bats`: the flag is set for an unreachable Docker, the warning names both runtimes when both fail, and neither the warning nor the flag appear when the runtimes answer.

Full suite passes locally (456 tests), and `shellcheck -x -s bash -e SC1091 utils/common.sh` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of existing instances when Docker or Podman is unavailable.
  * Added warnings when container inspection cannot be completed, preventing unavailable runtimes from being silently treated as having no existing instance.
* **Tests**
  * Added coverage for unavailable, failing, and healthy container runtime scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->