### PR TITLE
Detect the containers the installer deployed, not every ovos-* image

### DIFF
--- a/tests/bats/instance.bats
+++ b/tests/bats/instance.bats
@@ -18,14 +18,93 @@ function setup() {
         command uname "$@"
     }
     function docker() {
-        # Match the name-based detection in utils/common.sh
+        # A compose stack the installer deployed carries the project label.
         if [[ "$1" == "ps" ]]; then
-            echo "ovos_core"
+            if [[ "$*" == *"label=com.docker.compose.project=ovos"* ]]; then
+                echo "ovos-ovos_core-1"
+            fi
         fi
     }
     export -f uname docker
     detect_existing_instance
     assert_equal "$EXISTING_INSTANCE" "true"
+    assert_equal "$INSTANCE_TYPE" "containers"
+    unset uname docker
+}
+
+@test "function_detect_existing_instance_ignores_unrelated_ovos_containers" {
+    # Standalone ovos-tts-server / ovos-stt-server containers are not an
+    # instance the installer deployed, see issue #561.
+    RUN_AS_HOME="$BATS_TMPDIR/testuser4"
+    function uname() {
+        if [[ "$1" == "-s" ]]; then
+            echo "Linux"
+            return 0
+        fi
+        command uname "$@"
+    }
+    function docker() {
+        if [[ "$1" == "ps" ]]; then
+            if [[ "$*" == *"label=com.docker.compose.project="* ]]; then
+                return 0
+            fi
+            printf '%s\n' "ovos-tts-server" "ovos-stt-server" "ovos_tts_plugin"
+        fi
+    }
+    function podman() {
+        return 0
+    }
+    export -f uname docker podman
+    detect_existing_instance
+    assert_equal "$EXISTING_INSTANCE" "false"
+    unset uname docker podman
+}
+
+@test "function_detect_existing_instance_detects_hivemind_compose_project" {
+    RUN_AS_HOME="$BATS_TMPDIR/testuser4"
+    function uname() {
+        if [[ "$1" == "-s" ]]; then
+            echo "Linux"
+            return 0
+        fi
+        command uname "$@"
+    }
+    function docker() {
+        if [[ "$1" == "ps" ]]; then
+            if [[ "$*" == *"label=com.docker.compose.project=hivemind"* ]]; then
+                echo "hivemind-hivemind_listener-1"
+            fi
+        fi
+    }
+    export -f uname docker
+    detect_existing_instance
+    assert_equal "$EXISTING_INSTANCE" "true"
+    assert_equal "$INSTANCE_TYPE" "containers"
+    unset uname docker
+}
+
+@test "function_detect_existing_instance_detects_unlabelled_legacy_names" {
+    # Started outside compose, so no project label to match on.
+    RUN_AS_HOME="$BATS_TMPDIR/testuser4"
+    function uname() {
+        if [[ "$1" == "-s" ]]; then
+            echo "Linux"
+            return 0
+        fi
+        command uname "$@"
+    }
+    function docker() {
+        if [[ "$1" == "ps" ]]; then
+            if [[ "$*" == *"label=com.docker.compose.project="* ]]; then
+                return 0
+            fi
+            printf '%s\n' "ovos_messagebus"
+        fi
+    }
+    export -f uname docker
+    detect_existing_instance
+    assert_equal "$EXISTING_INSTANCE" "true"
+    assert_equal "$INSTANCE_TYPE" "containers"
     unset uname docker
 }
 

--- a/utils/common.sh
+++ b/utils/common.sh
@@ -165,34 +165,69 @@ function run_with_errexit_guard() {
     return "$status"
 }
 
-# Return success when an OCI runtime contains OVOS/HiveMind related containers.
+# Return success when an OCI runtime hosts an instance the installer deployed.
 function container_runtime_has_ovos_instance() {
     local runtime_cmd="$1"
     local runtime_label="$2"
     local name_regex="$3"
     local runtime_names=""
     local runtime_status=0
+    local project=""
+    local errexit_set=0
+
+    # The compose projects the installer deploys under, same list the
+    # uninstall role tears down.
+    local -a compose_projects=(ovos hivemind)
 
     if ! command -v "$runtime_cmd" &>>"$LOG_FILE"; then
         return 1
     fi
 
-    local errexit_set=0
     [[ $- == *e* ]] && errexit_set=1
-    set +e
-    runtime_names="$("$runtime_cmd" ps -a --format '{{.Names}}' 2>>"$LOG_FILE")"
-    runtime_status=$?
-    if [ "$errexit_set" -eq 1 ]; then
-        set -e
-    else
-        set +e
-    fi
 
-    if [ "$runtime_status" -eq 0 ] && printf '%s\n' "$runtime_names" | grep -Eq "$name_regex"; then
-        export EXISTING_INSTANCE="true"
-        export INSTANCE_TYPE="containers"
-        printf '%s\n' "[info] Existing OVOS instance detected via ${runtime_label} containers" &>>"$LOG_FILE"
-        return 0
+    # Match the compose project rather than the container name. Plenty of
+    # unrelated images are called ovos-something, an ovos-tts-server or an
+    # ovos-stt-server next to an unrelated stack is not a deployed instance.
+    for project in "${compose_projects[@]}"; do
+        set +e
+        runtime_names="$("$runtime_cmd" ps -a --filter "label=com.docker.compose.project=${project}" --format '{{.Names}}' 2>>"$LOG_FILE")"
+        runtime_status=$?
+        if [ "$errexit_set" -eq 1 ]; then
+            set -e
+        else
+            set +e
+        fi
+
+        if [ "$runtime_status" -ne 0 ]; then
+            break
+        fi
+
+        if [ -n "${runtime_names//[[:space:]]/}" ]; then
+            export EXISTING_INSTANCE="true"
+            export INSTANCE_TYPE="containers"
+            printf '%s\n' "[info] Existing OVOS instance detected via ${runtime_label} compose project ${project}" &>>"$LOG_FILE"
+            return 0
+        fi
+    done
+
+    # Anything started outside compose carries no project label, so fall back
+    # to the exact names the installer gives its own containers.
+    if [ "$runtime_status" -eq 0 ]; then
+        set +e
+        runtime_names="$("$runtime_cmd" ps -a --format '{{.Names}}' 2>>"$LOG_FILE")"
+        runtime_status=$?
+        if [ "$errexit_set" -eq 1 ]; then
+            set -e
+        else
+            set +e
+        fi
+
+        if [ "$runtime_status" -eq 0 ] && printf '%s\n' "$runtime_names" | grep -Eq "$name_regex"; then
+            export EXISTING_INSTANCE="true"
+            export INSTANCE_TYPE="containers"
+            printf '%s\n' "[info] Existing OVOS instance detected via ${runtime_label} containers" &>>"$LOG_FILE"
+            return 0
+        fi
     fi
 
     if [ "$runtime_status" -ne 0 ]; then
@@ -531,11 +566,11 @@ function detect_existing_instance() {
         skip_container_runtime_checks="true"
     fi
 
-    # Containers: detect by name (not ID), and only if the runtime exists.
-    # Compose project names are typically "ovos" or "hivemind" (container names
-    # become ovos_* / ovos-* or hivemind_* / hivemind-* depending on compose
-    # version). Keep legacy exact names too.
-    local name_regex='^(ovos[_-].*|hivemind[_-].*|ovos_cli|hivemind_cli|ovos_core|ovos_messagebus)$'
+    # Containers: detect by compose project first, see
+    # container_runtime_has_ovos_instance(). This list is only the fallback for
+    # containers started outside compose, so it stays exact. A prefix match
+    # here reports every unrelated ovos-* image as a deployed instance.
+    local name_regex='^(ovos_cli|hivemind_cli|ovos_core|ovos_messagebus)$'
 
     if [ "$skip_container_runtime_checks" != "true" ]; then
         if container_runtime_has_ovos_instance docker "Docker" "$name_regex"; then


### PR DESCRIPTION
Fixes the actual complaint in #561.

## Problem

`detect_existing_instance()` matched container names against this regex:

```
^(ovos[_-].*|hivemind[_-].*|ovos_cli|hivemind_cli|ovos_core|ovos_messagebus)$
```

Those first two alternatives are prefixes, so **any** container whose name starts with `ovos-`, `ovos_`, `hivemind-` or `hivemind_` counted as a deployed instance. The reporter has standalone OVOS TTS and STT containers on the host and neither OVOS nor HiveMind installed there:

> Yes, I've some (OVOS) TTS and STT containers running but not hivemind or Ovos itself at this device.

`ovos-tts-server` matches the prefix, so the installer pinned them to the containers method and gave no way to choose virtualenv. My earlier answer on that issue was wrong: the lock was not working as intended, this is a false positive.

## Change

The prefix was always wider than what the installer owns. `ovos_containers_uninstall_project_names` identifies the installer's own containers by compose project, `ovos` and `hivemind`, so detection now asks the same question:

```bash
docker ps -a --filter "label=com.docker.compose.project=ovos" --format '{{.Names}}'
```

A non-empty answer for either project means an instance is deployed. Compose sets that label on everything it creates, v1 and v2 alike, and a container started with `docker run` never has it, which is exactly the distinction that was missing.

The name match stays as a fallback for containers started outside compose, but it is now the exact service names rather than a prefix:

```
^(ovos_cli|hivemind_cli|ovos_core|ovos_messagebus)$
```

Detection is otherwise unchanged: same `EXISTING_INSTANCE` / `INSTANCE_TYPE` contract, same Podman probe after Docker, same unreachable-daemon warning from #562.

## Tests

Four cases in `tests/bats/instance.bats`: a labelled `ovos` stack is detected, a labelled `hivemind` stack is detected, unlabelled legacy names are still detected, and a host running only `ovos-tts-server` / `ovos-stt-server` / `ovos_tts_plugin` is **not**. The existing Docker and Podman stubs became argument-aware, since answering every `ps` identically no longer distinguishes the label query from the plain listing.

The false-positive test reproduces the bug on current main:

```
-- values do not equal --
expected : false
actual   : true
```

Full suite passes (465 tests), `shellcheck -x -s bash -e SC1091 utils/common.sh` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)