### PR TITLE
Restore the Python 2 macros swig 4.5.0 removed, so fann2 still builds

### DIFF
--- a/.github/scripts/run_virtualenv_role.sh
+++ b/.github/scripts/run_virtualenv_role.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Run the ovos_virtualenv role on its own, without setup.sh.
+#
+# Distributions that are not available as GitHub runners have to be covered
+# from a container, and a container has no init system for the launchd/systemd
+# work that a full setup.sh run performs. Driving the role directly still
+# exercises the package, virtualenv and build-shim tasks, which is where
+# distribution differences (compilers, swig, fann) actually show up.
+set -euo pipefail
+
+cleaning="${1:-false}"
+
+install_user="${OVOS_CI_INSTALL_USER:?OVOS_CI_INSTALL_USER is required}"
+install_home="${OVOS_CI_INSTALL_HOME:?OVOS_CI_INSTALL_HOME is required}"
+ansible_playbook="${OVOS_CI_ANSIBLE_PLAYBOOK:-/opt/ansible-venv/bin/ansible-playbook}"
+
+if [ ! -x "$ansible_playbook" ]; then
+    printf '%s\n' "ansible-playbook not found at ${ansible_playbook}" >&2
+    exit 1
+fi
+
+ANSIBLE_CONFIG="${PWD}/ansible.cfg" \
+    ANSIBLE_CALLBACKS_ENABLED="profile_tasks,timer" \
+    "$ansible_playbook" -i 127.0.0.1, ansible/site.yml \
+    -e "ovos_installer_user=${install_user}" \
+    -e "ovos_installer_group=${install_user}" \
+    -e "ovos_installer_uid=$(id -u "${install_user}")" \
+    -e "ovos_installer_user_home=${install_home}" \
+    -e "ovos_installer_method=virtualenv" \
+    -e "ovos_installer_profile=ovos" \
+    -e "ovos_installer_channel=testing" \
+    -e "ovos_installer_feature_gui=false" \
+    -e "ovos_installer_feature_skills=false" \
+    -e "ovos_installer_feature_extra_skills=false" \
+    -e "ovos_installer_feature_homeassistant=false" \
+    -e "ovos_installer_tuning=false" \
+    -e "ovos_installer_cleaning=${cleaning}" \
+    -e "ovos_installer_raspberrypi=N/A" \
+    -e "ovos_installer_hardware=N/A" \
+    -e "ovos_installer_sound_server=N/A" \
+    -e "ovos_installer_display_server=N/A" \
+    -e "ovos_installer_locale=en-us" \
+    -e "ovos_installer_reboot_file_path=/tmp/ovos.reboot" \
+    -e "ovos_installer_venv=${install_home}/.venvs/ovos" \
+    -e "ovos_installer_venv_python=3.11" \
+    -e '{"ovos_installer_i2c_devices":[]}' \
+    --tags ovos_virtualenv

--- a/.github/workflows/scenarios-archlinux.yml
+++ b/.github/workflows/scenarios-archlinux.yml
@@ -1,0 +1,123 @@
+name: Arch Linux installer CI
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/scenarios-archlinux.yml
+      - .github/scripts/run_virtualenv_role.sh
+      - ansible.cfg
+      - ansible/**
+  push:
+    paths:
+      - .github/workflows/scenarios-archlinux.yml
+      - .github/scripts/run_virtualenv_role.sh
+      - ansible.cfg
+      - ansible/**
+  schedule:
+    - cron: "40 3 * * *"
+  workflow_dispatch:
+
+jobs:
+  # Arch is the only released distribution shipping swig 4.5.0, which dropped
+  # the Python 2 compatibility macros that fann2 1.0.7 typemaps still call, so
+  # it is where the swig2.0 build shim has to keep working. Ubuntu 24.04 still
+  # ships swig 4.2 and cannot catch a regression here.
+  #
+  # GitHub has no Arch runner and a container has no init system for the
+  # systemd work setup.sh performs, so this drives the ovos_virtualenv role
+  # directly instead of the full installer.
+  archlinux-virtualenv-role:
+    runs-on: ubuntu-24.04
+    container:
+      image: ghcr.io/archlinux/archlinux:base-devel
+    timeout-minutes: 45
+
+    env:
+      OVOS_CI_INSTALL_USER: ovosci
+      OVOS_CI_INSTALL_HOME: /home/ovosci
+      # Keep in sync with ANSIBLE_VERSION in utils/common.sh.
+      OVOS_CI_ANSIBLE_VERSION: 10.7.0
+
+    steps:
+      - name: Install container prerequisites
+        run: pacman -Syu --noconfirm --needed base-devel git python python-pip sudo
+
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Report distribution toolchain
+        run: |
+          python3 --version
+          pacman -Si swig | awk '/^Version/ { print "swig: " $3; exit }'
+          pacman -Si gcc | awk '/^Version/ { print "gcc: " $3; exit }'
+
+      - name: Create installer user
+        run: |
+          useradd -m -s /bin/bash "$OVOS_CI_INSTALL_USER"
+          printf '%s ALL=(ALL) NOPASSWD: ALL\n' "$OVOS_CI_INSTALL_USER" \
+            > "/etc/sudoers.d/$OVOS_CI_INSTALL_USER"
+          chmod 0440 "/etc/sudoers.d/$OVOS_CI_INSTALL_USER"
+
+      - name: Install Ansible, collections and uv
+        run: |
+          python3 -m venv /opt/ansible-venv
+          /opt/ansible-venv/bin/pip install --quiet "ansible==${OVOS_CI_ANSIBLE_VERSION}"
+          /opt/ansible-venv/bin/ansible-galaxy collection install -r ansible/requirements.yml
+          sudo -u "$OVOS_CI_INSTALL_USER" \
+            python3 -m pip install --quiet --user --break-system-packages uv
+
+      - name: Run ovos_virtualenv role
+        run: .github/scripts/run_virtualenv_role.sh false
+
+      - name: Validate swig2.0 build shim
+        run: |
+          shim="${OVOS_CI_INSTALL_HOME}/.local/bin/swig2.0"
+
+          if [ -L "$shim" ]; then
+            echo "The shim is a symlink to swig; it cannot restore the macros swig 4.5.0 removed."
+            exit 1
+          fi
+
+          test -x "$shim"
+          grep -q "OVOS_SWIG_PY2_COMPAT" "$shim"
+
+      - name: Validate fann2 built against the installed swig
+        run: |
+          sudo -u "$OVOS_CI_INSTALL_USER" \
+            "${OVOS_CI_INSTALL_HOME}/.venvs/ovos/bin/python" - <<'PY'
+          from fann2 import libfann
+
+          network = libfann.neural_net()
+          network.create_standard_array([2, 3, 1])
+
+          assert network.get_num_input() == 2, network.get_num_input()
+          print("fann2 usable, num_input =", network.get_num_input())
+          PY
+
+      - name: Run ovos_virtualenv uninstall
+        run: .github/scripts/run_virtualenv_role.sh true
+
+      - name: Validate uninstall removed the build shim
+        run: |
+          shim="${OVOS_CI_INSTALL_HOME}/.local/bin/swig2.0"
+
+          if [ -e "$shim" ]; then
+            echo "The swig2.0 shim survived the uninstall."
+            exit 1
+          fi
+
+      - name: Dump diagnostics on failure
+        if: failure()
+        run: |
+          cat "${OVOS_CI_INSTALL_HOME}/.local/bin/swig2.0" || true
+          ls -la "${OVOS_CI_INSTALL_HOME}/.local/bin" || true
+          ls -la "${OVOS_CI_INSTALL_HOME}/.venvs/ovos/bin" || true
+          swig -version || true
+          pacman -Q swig fann gcc || true

--- a/ansible/roles/ovos_virtualenv/defaults/main.yml
+++ b/ansible/roles/ovos_virtualenv/defaults/main.yml
@@ -70,6 +70,7 @@ ovos_virtualenv_padatious_cache_staging_dir: "{{ ovos_virtualenv_padatious_cache
 ovos_virtualenv_padatious_cache_backup_dir: "{{ ovos_virtualenv_padatious_cache_dir }}.bak"
 ovos_virtualenv_padatious_cache_force_sync: "{{ ovos_installer_padatious_cache_force_sync | default(false) }}"
 ovos_virtualenv_messagebus_path: "{{ ovos_installer_user_home }}/.local/bin/ovos-messagebus"
+ovos_virtualenv_swig_shim_path: "{{ ovos_installer_user_home }}/.local/bin/swig2.0"
 ovos_virtualenv_rust_messagebus_repo: https://github.com/OscillateLabsLLC/ovos-rust-messagebus
 ovos_virtualenv_rust_messagebus_version: v2.1.1
 ovos_virtualenv_rust_messagebus_target_arch: >-

--- a/ansible/roles/ovos_virtualenv/tasks/packages.yml
+++ b/ansible/roles/ovos_virtualenv/tasks/packages.yml
@@ -224,11 +224,17 @@
     mode: "0755"
   when: ansible_facts.system in ['Linux', 'Darwin']
 
+# "command -v" is a shell builtin, unlike which(1), which is a separate package
+# that minimal images do not always carry. Resolving through it means a missing
+# which cannot silently skip the shim and break the fann2 build.
 - name: Resolve swig binary path for fann2 builds
   become: true
   become_user: "{{ ovos_installer_user }}"
   ansible.builtin.command:
-    cmd: "which swig"
+    argv:
+      - /bin/sh
+      - -c
+      - command -v swig
   register: ovos_virtualenv_swig_bin
   changed_when: false
   failed_when: false

--- a/ansible/roles/ovos_virtualenv/tasks/packages.yml
+++ b/ansible/roles/ovos_virtualenv/tasks/packages.yml
@@ -151,39 +151,6 @@
     ovos_installer_package_tracking_marker_path: "{{ ovos_virtualenv_package_marker_path_macos }}"
   when: ansible_facts.system == "Darwin"
 
-- name: Ensure user local bin directory exists for build compatibility shims (macOS)
-  ansible.builtin.file:
-    path: "{{ ovos_installer_user_home }}/.local/bin"
-    state: directory
-    owner: "{{ ovos_installer_user }}"
-    group: "{{ ovos_installer_group }}"
-    mode: "0755"
-  when: ansible_facts.system == "Darwin"
-
-- name: Resolve swig binary path for fann2 builds (macOS)
-  become: true
-  become_user: "{{ ovos_installer_user }}"
-  ansible.builtin.command:
-    cmd: "which swig"
-  register: ovos_virtualenv_macos_swig_bin
-  changed_when: false
-  failed_when: false
-  environment:
-    PATH: "{{ ovos_virtualenv_homebrew_path }}:{{ ansible_env.PATH | default('/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin') }}"
-  when: ansible_facts.system == "Darwin"
-
-- name: Ensure swig2.0 compatibility shim exists (macOS)
-  ansible.builtin.file:
-    src: "{{ ovos_virtualenv_macos_swig_bin.stdout | trim }}"
-    dest: "{{ ovos_installer_user_home }}/.local/bin/swig2.0"
-    state: link
-    force: true
-    owner: "{{ ovos_installer_user }}"
-    group: "{{ ovos_installer_group }}"
-  when:
-    - ansible_facts.system == "Darwin"
-    - (ovos_virtualenv_macos_swig_bin.stdout | default('') | trim | length) > 0
-
 - name: Check Homebrew fann lib directory for compatibility
   ansible.builtin.stat:
     path: "{{ ovos_virtualenv_macos_fann_source_lib_dir }}"
@@ -244,3 +211,42 @@
   vars:
     ovos_installer_package_tracking_marker_path: "{{ ovos_virtualenv_package_marker_path_linux }}"
   when: ansible_facts.os_family == "Archlinux"
+
+# Every platform builds fann2 from source (ovos-core[lgpl] pulls it in) and
+# fann2 1.0.7 prefers a "swig2.0" binary, so these run wherever swig was just
+# installed - the shim has to come after the package tasks above.
+- name: Ensure user local bin directory exists for build compatibility shims
+  ansible.builtin.file:
+    path: "{{ ovos_installer_user_home }}/.local/bin"
+    state: directory
+    owner: "{{ ovos_installer_user }}"
+    group: "{{ ovos_installer_group }}"
+    mode: "0755"
+  when: ansible_facts.system in ['Linux', 'Darwin']
+
+- name: Resolve swig binary path for fann2 builds
+  become: true
+  become_user: "{{ ovos_installer_user }}"
+  ansible.builtin.command:
+    cmd: "which swig"
+  register: ovos_virtualenv_swig_bin
+  changed_when: false
+  failed_when: false
+  environment:
+    PATH: "{{ ovos_virtualenv_homebrew_path }}:{{ ansible_env.PATH | default('/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin') }}"
+  when: ansible_facts.system in ['Linux', 'Darwin']
+
+# swig 4.5.0 dropped the Python 2 compatibility macros from its generated
+# wrappers, which fann2 1.0.7 typemaps still call. The shim runs the real swig
+# and restores those macros, so it is a wrapper script rather than a symlink.
+- name: Ensure swig2.0 compatibility shim exists
+  ansible.builtin.template:
+    src: swig2.0-shim.sh.j2
+    dest: "{{ ovos_virtualenv_swig_shim_path }}"
+    owner: "{{ ovos_installer_user }}"
+    group: "{{ ovos_installer_group }}"
+    mode: "0755"
+    follow: false
+  when:
+    - ansible_facts.system in ['Linux', 'Darwin']
+    - (ovos_virtualenv_swig_bin.stdout | default('') | trim | length) > 0

--- a/ansible/roles/ovos_virtualenv/tasks/uninstall.yml
+++ b/ansible/roles/ovos_virtualenv/tasks/uninstall.yml
@@ -261,7 +261,8 @@
       {{ _remove_venv_paths
          + _requirements_paths
          + ovos_virtualenv_uninstall_extra_paths
-         + [ovos_virtualenv_messagebus_path, ovos_virtualenv_rust_messagebus_binary_path]
+         + [ovos_virtualenv_messagebus_path, ovos_virtualenv_rust_messagebus_binary_path,
+            ovos_virtualenv_swig_shim_path]
          | unique }}
   ansible.builtin.file:
     path: "{{ item }}"

--- a/ansible/roles/ovos_virtualenv/templates/swig2.0-shim.sh.j2
+++ b/ansible/roles/ovos_virtualenv/templates/swig2.0-shim.sh.j2
@@ -1,0 +1,103 @@
+#!/bin/sh
+# Managed by ovos-installer - do not edit.
+#
+# fann2 1.0.7 prefers a "swig2.0" binary and its typemaps still call the
+# Python 2 C API (PyInt_AsLong, PyInt_FromLong). Until SWIG 4.5.0 the
+# generated wrapper carried compatibility macros that mapped those onto the
+# Python 3 API; 4.5.0 removed them, so the wrapper no longer compiles. Run the
+# real swig, then put the removed macros back when the generated wrapper still
+# needs them.
+
+set -u
+
+swig_bin="{{ ovos_virtualenv_swig_bin.stdout | trim }}"
+
+"${swig_bin}" "$@"
+swig_status=$?
+[ "${swig_status}" -eq 0 ] || exit "${swig_status}"
+
+# Work out which wrapper swig just generated: an explicit -o wins, otherwise
+# swig writes <input>_wrap.cxx (C++) or <input>_wrap.c next to the interface.
+wrapper=""
+interface=""
+extension="c"
+expect_output=0
+
+for arg in "$@"; do
+    if [ "${expect_output}" -eq 1 ]; then
+        wrapper="${arg}"
+        expect_output=0
+        continue
+    fi
+    case "${arg}" in
+        -c++) extension="cxx" ;;
+        -o) expect_output=1 ;;
+        *.i) interface="${arg}" ;;
+    esac
+done
+
+if [ -z "${wrapper}" ]; then
+    [ -n "${interface}" ] || exit 0
+    wrapper="${interface%.i}_wrap.${extension}"
+fi
+
+[ -f "${wrapper}" ] || exit 0
+
+# Nothing to do when this swig still ships the macros, or we already patched.
+grep -q "OVOS_SWIG_PY2_COMPAT" "${wrapper}" && exit 0
+grep -q "define PyInt_AsLong" "${wrapper}" && exit 0
+grep -q -E "PyInt_|PyString_|PyClass_Check|Py_TPFLAGS_HAVE_CLASS|_PyLong_FromSsize_t" "${wrapper}" || exit 0
+
+patched="${wrapper}.ovos-swig-compat"
+cat > "${patched}" <<'EOF'
+/* OVOS_SWIG_PY2_COMPAT - Python 2 C API macros dropped from SWIG's pyhead.swg
+   in 4.5.0, restored for interface files whose typemaps still call them.
+   Macro definitions only, so this needs no Python.h of its own: swig still
+   includes it (with PY_SSIZE_T_CLEAN) further down the generated wrapper. */
+#ifndef PyClass_Check
+#define PyClass_Check(obj) PyObject_IsInstance(obj, (PyObject *)&PyType_Type)
+#endif
+#ifndef PyInt_Check
+#define PyInt_Check(x) PyLong_Check(x)
+#endif
+#ifndef PyInt_AsLong
+#define PyInt_AsLong(x) PyLong_AsLong(x)
+#endif
+#ifndef PyInt_FromLong
+#define PyInt_FromLong(x) PyLong_FromLong(x)
+#endif
+#ifndef PyInt_FromSize_t
+#define PyInt_FromSize_t(x) PyLong_FromSize_t(x)
+#endif
+#ifndef PyString_Check
+#define PyString_Check(name) PyBytes_Check(name)
+#endif
+#ifndef PyString_FromString
+#define PyString_FromString(x) PyUnicode_FromString(x)
+#endif
+#ifndef PyString_Format
+#define PyString_Format(fmt, args) PyUnicode_Format(fmt, args)
+#endif
+#ifndef PyString_AsString
+#define PyString_AsString(str) PyBytes_AsString(str)
+#endif
+#ifndef PyString_Size
+#define PyString_Size(str) PyBytes_Size(str)
+#endif
+#ifndef PyString_InternFromString
+#define PyString_InternFromString(key) PyUnicode_InternFromString(key)
+#endif
+#ifndef Py_TPFLAGS_HAVE_CLASS
+#define Py_TPFLAGS_HAVE_CLASS Py_TPFLAGS_BASETYPE
+#endif
+#ifndef _PyLong_FromSsize_t
+#define _PyLong_FromSsize_t(x) PyLong_FromSsize_t(x)
+#endif
+EOF
+
+if cat "${wrapper}" >> "${patched}"; then
+    mv "${patched}" "${wrapper}"
+else
+    rm -f "${patched}"
+    exit 1
+fi

--- a/tests/bats/code_quality.bats
+++ b/tests/bats/code_quality.bats
@@ -815,17 +815,49 @@ function setup() {
     assert_success
 }
 
-@test "macos_fann2_build_has_swig2_compatibility_shim" {
-    run grep -q "Resolve swig binary path for fann2 builds (macOS)" ansible/roles/ovos_virtualenv/tasks/packages.yml
+@test "fann2_build_has_swig2_compatibility_shim" {
+    local tasks="ansible/roles/ovos_virtualenv/tasks/packages.yml"
+    local shim="ansible/roles/ovos_virtualenv/templates/swig2.0-shim.sh.j2"
+
+    run grep -q "Resolve swig binary path for fann2 builds" "$tasks"
     assert_success
 
-    run bash -c "grep -A8 -F -- \"- name: Resolve swig binary path for fann2 builds (macOS)\" ansible/roles/ovos_virtualenv/tasks/packages.yml | grep -q -- \"failed_when: false\""
+    run bash -c "grep -A8 -F -- \"- name: Resolve swig binary path for fann2 builds\" ansible/roles/ovos_virtualenv/tasks/packages.yml | grep -q -- \"failed_when: false\""
     assert_success
 
-    run grep -q "Ensure swig2.0 compatibility shim exists (macOS)" ansible/roles/ovos_virtualenv/tasks/packages.yml
+    run grep -q "Ensure swig2.0 compatibility shim exists" "$tasks"
     assert_success
 
-    run grep -q "dest: \"{{ ovos_installer_user_home }}/.local/bin/swig2.0\"" ansible/roles/ovos_virtualenv/tasks/packages.yml
+    run grep -q "dest: \"{{ ovos_virtualenv_swig_shim_path }}\"" "$tasks"
+    assert_success
+
+    # fann2 is built from source on every platform, so the shim is not macOS only.
+    run bash -c "grep -A12 -F -- \"- name: Ensure swig2.0 compatibility shim exists\" ansible/roles/ovos_virtualenv/tasks/packages.yml | grep -q -F -- \"ansible_facts.system in ['Linux', 'Darwin']\""
+    assert_success
+
+    # The shim has to be a wrapper script, not a symlink: swig 4.5.0 dropped the
+    # Python 2 compatibility macros that fann2 typemaps still call.
+    run bash -c "grep -A6 -F -- \"- name: Ensure swig2.0 compatibility shim exists\" ansible/roles/ovos_virtualenv/tasks/packages.yml | grep -q -- \"src: swig2.0-shim.sh.j2\""
+    assert_success
+
+    run test -f "$shim"
+    assert_success
+
+    run grep -q "{{ ovos_virtualenv_swig_bin.stdout | trim }}" "$shim"
+    assert_success
+
+    run grep -q "define PyInt_AsLong(x) PyLong_AsLong(x)" "$shim"
+    assert_success
+
+    run grep -q "define PyInt_FromLong(x) PyLong_FromLong(x)" "$shim"
+    assert_success
+
+    # Leave wrappers alone when swig still ships the macros itself.
+    run grep -q 'grep -q "define PyInt_AsLong" "${wrapper}" && exit 0' "$shim"
+    assert_success
+
+    # The shim is installed by the role, so uninstall has to take it away again.
+    run grep -q "ovos_virtualenv_swig_shim_path" ansible/roles/ovos_virtualenv/tasks/uninstall.yml
     assert_success
 }
 

--- a/tests/bats/code_quality.bats
+++ b/tests/bats/code_quality.bats
@@ -822,8 +822,16 @@ function setup() {
     run grep -q "Resolve swig binary path for fann2 builds" "$tasks"
     assert_success
 
-    run bash -c "grep -A8 -F -- \"- name: Resolve swig binary path for fann2 builds\" ansible/roles/ovos_virtualenv/tasks/packages.yml | grep -q -- \"failed_when: false\""
+    run bash -c "grep -A12 -F -- \"- name: Resolve swig binary path for fann2 builds\" ansible/roles/ovos_virtualenv/tasks/packages.yml | grep -q -- \"failed_when: false\""
     assert_success
+
+    # command -v is a shell builtin, which(1) is a package that minimal images
+    # do not always ship. Resolving through it must not regress to which.
+    run bash -c "grep -A12 -F -- \"- name: Resolve swig binary path for fann2 builds\" ansible/roles/ovos_virtualenv/tasks/packages.yml | grep -q -F -- \"command -v swig\""
+    assert_success
+
+    run bash -c "grep -A12 -F -- \"- name: Resolve swig binary path for fann2 builds\" ansible/roles/ovos_virtualenv/tasks/packages.yml | grep -q -F -- \"which swig\""
+    assert_failure
 
     run grep -q "Ensure swig2.0 compatibility shim exists" "$tasks"
     assert_success

--- a/tests/bats/code_quality.bats
+++ b/tests/bats/code_quality.bats
@@ -3150,6 +3150,37 @@ YAML
 
     run grep -F -q "cancel-in-progress: true" .github/workflows/scenarios-ubuntu2404.yml
     assert_success
+
+    run grep -F -q "cancel-in-progress: true" .github/workflows/scenarios-archlinux.yml
+    assert_success
+}
+
+@test "archlinux_ci_covers_fann2_build_on_swig_4_5" {
+    local workflow=".github/workflows/scenarios-archlinux.yml"
+    local runner=".github/scripts/run_virtualenv_role.sh"
+
+    run test -f "$workflow"
+    assert_success
+
+    # Ubuntu 24.04 still ships swig 4.2, so only a rolling distribution can
+    # catch a regression in the swig2.0 shim fann2 1.0.7 needs.
+    run grep -F -q "image: ghcr.io/archlinux/archlinux:base-devel" "$workflow"
+    assert_success
+
+    run grep -F -q "OVOS_SWIG_PY2_COMPAT" "$workflow"
+    assert_success
+
+    run grep -F -q "from fann2 import libfann" "$workflow"
+    assert_success
+
+    run test -x "$runner"
+    assert_success
+
+    run grep -F -q -- "--tags ovos_virtualenv" "$runner"
+    assert_success
+
+    run grep -F -q "ovos_installer_cleaning=\${cleaning}" "$runner"
+    assert_success
 }
 
 @test "ci_uses_profile_tasks_callback_and_runtime_thresholds" {


### PR DESCRIPTION
## What broke

`macos-scenario-matrix (macos-15-intel, testing, ovos, *)` has been failing since 2026-08-08, on every branch:

```
TASK [ovos_virtualenv : Install Open Voice OS in Python venv]
× Failed to build `fann2==1.0.7`
  fann2/fann2_wrap.cxx:10062:41: error: use of undeclared identifier 'PyInt_AsLong'
  … 7 errors
hint: `fann2` (v1.0.7) was included because `ovos-core[lgpl]` (v2.1.1) depends on `fann2`
```

`fann2` 1.0.7 ships no wrapper — `setup.py` runs swig over `fann2/fann2.i` at build time, and line 192 of that interface file calls `PyInt_AsLong`/`PyInt_FromLong`. Every swig up to 4.4.1 emitted compatibility macros mapping those onto the Python 3 API. SWIG removed them on 2026-07-06 ("Removed the Python 2 compatibility macros … *** POTENTIAL INCOMPATIBILITY ***"), released as 4.5.0, which Homebrew shipped on 2026-08-06.

Only `macos-15-intel` fails because the role installs with `update_homebrew: false`, so each image resolves swig from its own baked formula index; macos-14 still gets a pre-4.5 swig and would break on its next refresh.

## The fix

The `swig2.0` shim was a symlink to the real swig, which does nothing to help here. It becomes a wrapper script that runs the real swig and then prepends the removed macros when the generated wrapper still needs them. It no-ops when swig defines the macros itself, so nothing changes on older toolchains.

`fann2` is built from source on every platform, so the shim is no longer macOS only. Distributions already carrying swig 4.5.0: Arch (2026-08-06), Fedora 45, Debian sid/forky. Safe for now: Ubuntu 24.04 (4.2), Debian trixie (4.3), Fedora 44 (4.4.1) — which is why Linux CI is still green.

Uninstall now removes the shim, which the old symlink never did.

## CI coverage

Ubuntu 24.04 can't catch a regression here. The new job runs in an Arch container (the only released distribution with swig 4.5.0 today, and rolling, so it stays current without a version bump). GitHub has no Arch runner and a container has no init for the systemd work `setup.sh` performs, so the job drives the `ovos_virtualenv` role directly — still covering the package, virtualenv and build-shim tasks, which is where distribution differences show up.

It asserts the shim is a script rather than a symlink, that `fann2` imports and builds a network from the OVOS venv, and that uninstall takes the shim away.

## Verification

Against genuine swig 4.5.0, not a simulation:

- **Fedora 45 container** (swig 4.5.0): `pip install fann2==1.0.7` fails with 14 `PyInt_` diagnostics; with the shim on `PATH` it builds, imports, and runs a network.
- **Arch container** (swig 4.5.0-1, Python 3.14.7), running the new workflow's own steps extracted from the YAML: install pass `ok=85 changed=24 failed=0`, `fann2 usable, num_input = 2`; uninstall pass `ok=34 changed=6 failed=0`, shim removed. Whole run exit 0.
- Passthrough on swig 4.4.1: wrapper untouched, no double-define, still compiles.
- Also checked: re-running patches exactly once, `-o` output resolution, swig's non-zero exit propagating.
- `yamllint`, `actionlint` (with shellcheck on `PATH`, so inline `run:` bodies are covered), `shellcheck -x -s bash -e SC1091`, and `ansible-lint --profile production` all clean.

## Noticed while testing, not addressed here

The playbook does not run on modern ansible-core. With Arch's `ansible-core 2.21.3` it fails immediately at `ansible/roles/ovos_installer/tasks/assert.yml:10` — 2.21 rejects `when:` conditionals whose `regex_search` returns `None` ("Conditionals must have a boolean result"). The pinned `ansible==10.7.0` from `utils/common.sh` is fine, which is why the new job installs it explicitly, but that pin is doing load-bearing work and probably deserves its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved SWIG compatibility for building `fann2` on Linux and macOS, including newer SWIG releases.
  - Added automatic handling for Python compatibility macros in generated bindings.

- **Improvements**
  - Ensured compatibility tooling is removed during uninstallation.
  - Added a standalone installation workflow with configurable cleanup.
  - Added Arch Linux installation and removal validation.

- **Tests**
  - Expanded automated coverage for Linux, macOS, Arch Linux, and newer SWIG versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->