### PR TITLE
Retry the tool downloads instead of ending the install on a blip

### DIFF
--- a/.github/workflows/macos_ci.yml
+++ b/.github/workflows/macos_ci.yml
@@ -281,3 +281,7 @@ jobs:
           launchctl list | grep -E 'ovos|hivemind' || true
           ls -la "$HOME/Library/LaunchAgents" || true
           ls -la "$HOME/.local/state/mycroft/logs" || true
+          # The installer tells you to read this file when it gives up, so it
+          # belongs in the job output. Without it a CI failure is undebuggable.
+          sudo tail -n 200 /var/log/ovos-installer.log || true
+          sudo tail -n 200 /var/log/ovos-ansible.log || true

--- a/tests/bats/utility_functions.bats
+++ b/tests/bats/utility_functions.bats
@@ -404,3 +404,44 @@ function teardown() {
     unset curl
     rm -f "$LOG_FILE"
 }
+
+@test "function_download_with_retry_passes_the_remaining_budget_to_curl" {
+    LOG_FILE="$(mktemp)"
+    args_file="$(mktemp)"
+    function curl() {
+        printf '%s\n' "$*" >>"$args_file"
+        return 22
+    }
+    export -f curl
+    DOWNLOAD_MAX_ATTEMPTS=2
+    DOWNLOAD_TIMEOUT=120
+    run download_with_retry "https://example.invalid/tool" "$BATS_TMPDIR/tool"
+    assert_failure
+
+    # Each attempt gets what is left of the one budget, never a fresh 120s.
+    first="$(sed -n '1p' "$args_file" | sed -E 's/.*--max-time ([0-9]+).*/\1/')"
+    second="$(sed -n '2p' "$args_file" | sed -E 's/.*--max-time ([0-9]+).*/\1/')"
+    [ "$first" -le 120 ]
+    [ "$second" -le "$first" ]
+    unset curl
+    rm -f "$LOG_FILE" "$args_file"
+}
+
+@test "function_download_with_retry_stops_when_the_budget_is_gone" {
+    LOG_FILE="$(mktemp)"
+    attempts_file="$(mktemp)"
+    function curl() {
+        echo "call" >>"$attempts_file"
+        return 22
+    }
+    export -f curl
+    DOWNLOAD_MAX_ATTEMPTS=3
+    DOWNLOAD_TIMEOUT=0
+    run download_with_retry "https://example.invalid/tool" "$BATS_TMPDIR/tool"
+    assert_failure
+    assert_equal "$(wc -l <"$attempts_file" | tr -d ' ')" "0"
+    run grep -c "budget of 0s exhausted" "$LOG_FILE"
+    assert_output "1"
+    unset curl
+    rm -f "$LOG_FILE" "$attempts_file"
+}

--- a/tests/bats/utility_functions.bats
+++ b/tests/bats/utility_functions.bats
@@ -334,3 +334,73 @@ function teardown() {
     unset PIP_CONFIG_FILE OVOS_INSTALLER_PIP_CONFIG_FILE OVOS_INSTALLER_SYSTEM_PIP_CONFIG_FILE
     unset RUN_AS SOUND_SERVER CPU_IS_CAPABLE
 }
+
+@test "function_download_with_retry_succeeds_on_first_attempt" {
+    LOG_FILE="$(mktemp)"
+    attempts_file="$(mktemp)"
+    function curl() {
+        echo "call" >>"$attempts_file"
+        printf 'payload' >"${!#}"
+        return 0
+    }
+    export -f curl
+    run download_with_retry "https://example.invalid/tool" "$BATS_TMPDIR/tool"
+    assert_success
+    assert_equal "$(wc -l <"$attempts_file" | tr -d ' ')" "1"
+    unset curl
+    rm -f "$LOG_FILE" "$attempts_file"
+}
+
+@test "function_download_with_retry_retries_a_transient_failure" {
+    LOG_FILE="$(mktemp)"
+    attempts_file="$(mktemp)"
+    # Fail once, then succeed: a blip must not end the installation.
+    function curl() {
+        echo "call" >>"$attempts_file"
+        if [ "$(wc -l <"$attempts_file" | tr -d ' ')" -lt 2 ]; then
+            return 22
+        fi
+        printf 'payload' >"${!#}"
+        return 0
+    }
+    export -f curl
+    DOWNLOAD_MAX_ATTEMPTS=3
+    run download_with_retry "https://example.invalid/tool" "$BATS_TMPDIR/tool"
+    assert_success
+    assert_equal "$(wc -l <"$attempts_file" | tr -d ' ')" "2"
+    unset curl
+    rm -f "$LOG_FILE" "$attempts_file"
+}
+
+@test "function_download_with_retry_gives_up_after_the_last_attempt" {
+    LOG_FILE="$(mktemp)"
+    attempts_file="$(mktemp)"
+    function curl() {
+        echo "call" >>"$attempts_file"
+        return 22
+    }
+    export -f curl
+    DOWNLOAD_MAX_ATTEMPTS=2
+    run download_with_retry "https://example.invalid/tool" "$BATS_TMPDIR/tool"
+    assert_failure
+    assert_equal "$(wc -l <"$attempts_file" | tr -d ' ')" "2"
+    run grep -c "download failed" "$LOG_FILE"
+    assert_output "2"
+    unset curl
+    rm -f "$LOG_FILE" "$attempts_file"
+}
+
+@test "function_download_yq_reports_a_failed_download" {
+    LOG_FILE="$(mktemp)"
+    YQ_BINARY_PATH="$BATS_TMPDIR/yq"
+    DOWNLOAD_MAX_ATTEMPTS=1
+    function curl() {
+        return 22
+    }
+    export -f curl
+    run download_yq
+    assert_failure
+    assert_output --partial "Unable to download yq"
+    unset curl
+    rm -f "$LOG_FILE"
+}

--- a/utils/common.sh
+++ b/utils/common.sh
@@ -1382,6 +1382,32 @@ function install_ansible() {
 # Downloads the yq tool from GitHub to parse YAML scenario file.
 # The binary will be downloaded based on the found operating system and CPU
 # architecture.
+# Fetch a file, retrying a few times before giving up. These downloads come
+# from release CDNs partway through an install that has already done real
+# work, so a single transient failure must not be the end of it.
+function download_with_retry() {
+    local url="$1"
+    local destination="$2"
+    local max_attempts="${DOWNLOAD_MAX_ATTEMPTS:-3}"
+    local attempt=1
+
+    while [ "$attempt" -le "$max_attempts" ]; do
+        if curl -sSfL --connect-timeout 15 --max-time 300 "$url" -o "$destination" 2>>"$LOG_FILE"; then
+            return 0
+        fi
+
+        rm -f "$destination"
+        printf '%s\n' "[warn] download failed (attempt ${attempt}/${max_attempts}): ${url}" &>>"$LOG_FILE"
+        attempt=$((attempt + 1))
+
+        if [ "$attempt" -le "$max_attempts" ]; then
+            sleep "$((attempt * 2))"
+        fi
+    done
+
+    return 1
+}
+
 function download_yq() {
     if [ -f "$YQ_BINARY_PATH" ]; then
         rm "$YQ_BINARY_PATH"
@@ -1409,7 +1435,12 @@ function download_yq() {
     esac
     kernel="$(uname -s 2>>"$LOG_FILE")"
 
-    curl -s -f -L "$YQ_URL/yq_${kernel,,}_$arch" -o "$YQ_BINARY_PATH" &>>"$LOG_FILE"
+    if ! download_with_retry "$YQ_URL/yq_${kernel,,}_$arch" "$YQ_BINARY_PATH"; then
+        echo -e "[$fail_format]"
+        log_error "➤ Unable to download yq from $YQ_URL after ${DOWNLOAD_MAX_ATTEMPTS:-3} attempts."
+        log_error "➤ Check the network connection to GitHub releases, then run the installer again."
+        return 1
+    fi
     chmod 0755 "$YQ_BINARY_PATH" &>>"$LOG_FILE"
 }
 
@@ -1888,7 +1919,7 @@ function setup_avrdude() {
         rm "$AVRDUDE_BINARY_PATH"
     fi
 
-    if ! curl -s -f -L "$avrdude_binary_url" -o "$AVRDUDE_BINARY_PATH" &>>"$LOG_FILE"; then
+    if ! download_with_retry "$avrdude_binary_url" "$AVRDUDE_BINARY_PATH"; then
         printf '%s\n' "[warn] Failed to download avrdude binary for Mark 1 detection." >>"$LOG_FILE"
         return 1
     fi
@@ -1923,7 +1954,7 @@ EOF
         return 1
     fi
 
-    if ! curl -s -f -L "$avrdude_config_url" -o "$AVRDUDE_CONFIG_PATH" &>>"$LOG_FILE"; then
+    if ! download_with_retry "$avrdude_config_url" "$AVRDUDE_CONFIG_PATH"; then
         printf '%s\n' "[warn] Failed to download avrdude configuration for Mark 1 detection." >>"$LOG_FILE"
         return 1
     fi

--- a/utils/common.sh
+++ b/utils/common.sh
@@ -1389,10 +1389,24 @@ function download_with_retry() {
     local url="$1"
     local destination="$2"
     local max_attempts="${DOWNLOAD_MAX_ATTEMPTS:-3}"
+    local budget="${DOWNLOAD_TIMEOUT:-300}"
     local attempt=1
+    local deadline
+    local remaining
+    local backoff
+
+    # One deadline for the whole call, not per attempt: retrying a stalled
+    # download must not multiply the time the installer sits there.
+    deadline=$(($(date +%s) + budget))
 
     while [ "$attempt" -le "$max_attempts" ]; do
-        if curl -sSfL --connect-timeout 15 --max-time 300 "$url" -o "$destination" 2>>"$LOG_FILE"; then
+        remaining=$((deadline - $(date +%s)))
+        if [ "$remaining" -le 0 ]; then
+            printf '%s\n' "[warn] download budget of ${budget}s exhausted: ${url}" &>>"$LOG_FILE"
+            return 1
+        fi
+
+        if curl -sSfL --connect-timeout 15 --max-time "$remaining" "$url" -o "$destination" 2>>"$LOG_FILE"; then
             return 0
         fi
 
@@ -1401,7 +1415,14 @@ function download_with_retry() {
         attempt=$((attempt + 1))
 
         if [ "$attempt" -le "$max_attempts" ]; then
-            sleep "$((attempt * 2))"
+            backoff=$((attempt * 2))
+            remaining=$((deadline - $(date +%s)))
+            if [ "$backoff" -gt "$remaining" ]; then
+                backoff="$remaining"
+            fi
+            if [ "$backoff" -gt 0 ]; then
+                sleep "$backoff"
+            fi
         fi
     done
 


### PR DESCRIPTION
## Problem

`download_yq()` was a single `curl -s -f -L` with no retry and no timeout, and its exit status was left to the ERR trap. One transient failure fetching yq from GitHub releases ends the run, partway through an install that has already done real work, with output that never names the cause:

```
➤ Installing Ansible requirements in Python virtualenv... [done]
[fail]
➤ Looking for automated scenario...
➤ Unable to finalize the process, please check /var/log/ovos-installer.log for more details.
```

That is what took down `macos-scenario-matrix (macos-15-intel, testing, ovos, all)` on #568: the failing step was the **uninstall** smoke test, the trace lands in `find_scenario` → `download_yq`, and there is an 11 second gap before the trap fires. The same commit passed on the other matrix entries, and main was green an hour earlier.

The two avrdude downloads had the same shape, though they at least checked the status.

## Change

`download_with_retry()` gives all three release downloads three attempts with a backoff, a connect timeout and a total timeout:

```bash
curl -sSfL --connect-timeout 15 --max-time 300 "$url" -o "$destination"
```

Each failed attempt is logged with its number, so the log says how hard it tried. When yq genuinely cannot be fetched, the installer now says so and names the network as the thing to check, instead of failing silently into the trap.

## CI could not diagnose this

`macos_ci.yml` dumps launchd state on failure but never `/var/log/ovos-installer.log`, which is the file the installer tells you to read. That is why the failure could not be diagnosed from the job output. The failure step now dumps the installer and ansible logs too.

## Tests

Four cases in `tests/bats/utility_functions.bats`, stubbing `curl`: success on the first attempt makes exactly one call, a transient failure retries and succeeds on the second, exhausting the attempts fails and logs one line per attempt, and `download_yq` surfaces "Unable to download yq" rather than returning silently.

476 tests pass, shellcheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability for downloading required tools and configuration files by retrying transient failures.
  * Removes incomplete downloads after repeated failures and provides clearer error reporting.

* **Tests**
  * Added coverage for successful downloads, retry recovery, retry exhaustion, cleanup, and error propagation.

* **Chores**
  * macOS build diagnostics now include installer and configuration-management logs when jobs fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->