### PR TITLE
Walk the whole TUI under nounset, the way setup.sh runs it

### DIFF
--- a/tests/bats/tui_lists.bats
+++ b/tests/bats/tui_lists.bats
@@ -159,6 +159,12 @@ function setup() {
 
     # Scratch locale directory for tests that need a locale of their own.
     SCRATCH_LOCALE_DIR="tui/locales/zz-test"
+
+    # setup.sh leaves nounset on for the whole TUI, so the screens have to be
+    # exercised the way the installer actually runs them. Without this the
+    # tests only ever see variables the test itself has set, which is how the
+    # INSTANCE_TYPE crash in #567 reached users.
+    set -u
 }
 
 function spy_value() {
@@ -1457,4 +1463,47 @@ LOCALE
     assert_equal "$TITLE" "Untranslated"
     [[ "$CONTENT" == *"An existing installation of Open Voice OS was detected"* ]]
     [[ "$CONTENT" == *"Detected method: containers"* ]]
+}
+
+@test "tui: a fresh install walks every screen under nounset" {
+    # The screens were only ever exercised one at a time, with the variables
+    # the test itself had set. That is why #567 shipped: nothing ran the flow
+    # the way setup.sh does, under nounset, with INSTANCE_TYPE absent because
+    # detect_existing_instance() found nothing.
+    #
+    # This drives tui/main.sh end to end with only what the detect_* stages
+    # actually export on a plain machine with no instance installed.
+    LOCALE="en-us"
+    EXISTING_INSTANCE="false"
+    unset INSTANCE_TYPE
+
+    ARCH="x86_64"
+    DISTRO_NAME="ubuntu"
+    DISTRO_VERSION="Ubuntu 24.04"
+    DISTRO_VERSION_ID="24"
+    DISTRO_LABEL="Ubuntu 24.04"
+    KERNEL="6.8.0"
+    PYTHON="Python 3.12.3"
+    CPU_IS_CAPABLE="true"
+    SOUND_SERVER="PipeWire"
+    DISPLAY_SERVER="wayland"
+    VENV_PATH="$RUN_AS_HOME/.venvs/ovos"
+    RASPBERRYPI_MODEL="N/A"
+    HARDWARE_MODEL="N/A"
+    DETECTED_DEVICES=()
+
+    # Let every dialog take its own first option, so the walk does not depend
+    # on choices this test would have to keep in step with the screens.
+    WHIPTAIL_FORCE_SELECTION=""
+    WHIPTAIL_FORCE_YESNO_STATUS="0"
+
+    set -u
+    # shellcheck source=tui/main.sh
+    source tui/main.sh
+    set +u
+
+    # Reaching the end means every screen sourced its locale and rendered.
+    assert_equal "$METHOD" "containers"
+    [ -n "$CHANNEL" ]
+    [ -n "$PROFILE" ]
 }


### PR DESCRIPTION
Closes the harness gap left by #570.

## The gap

#570 made the locale *strings* nounset-safe and proved it. But the crash in #567 was reached through `tui/methods.sh`, and the screens themselves were never run the way the installer runs them:

```
methods.sh    sourced_by_tests=1  under_nounset=2   <- only after #570
summary.sh    sourced_by_tests=1  under_nounset=0
features.sh   sourced_by_tests=1  under_nounset=0
llm.sh        sourced_by_tests=2  under_nounset=0
... 15 more, all under_nounset=0
```

Each test set the variables its screen happened to read, so a variable the installer does *not* always set could not be noticed. `INSTANCE_TYPE` is exactly that: `detect_existing_instance()` unsets it, and every fresh install takes that path.

## Change

Two things, both cheap:

- The TUI harness sets `set -u` in `setup`, matching `setup.sh`, which leaves nounset on for the whole TUI. A test can no longer pass by accident on a variable the installer would not have set. All 60 existing cases still pass, so this locks in current behaviour rather than papering over it.
- A new case drives `tui/main.sh` end to end with only what the `detect_*` stages export on a plain machine with no instance installed, and with `INSTANCE_TYPE` unset. Every dialog takes its own first option, so the walk does not have to be kept in step with the individual screens.

## It catches the bug it exists for

Against the files as they were before #569, through the real entry point rather than a locale sourced on its own:

```
not ok 1 tui: a fresh install walks every screen under nounset
  from function `source' in file tui/locales/en-us/methods.sh, line 22,
  from function `source' in file tui/methods.sh, line 7,
  from function `source' in file tui/main.sh, line 15
tui/locales/en-us/methods.sh: line 22: INSTANCE_TYPE: unbound variable
```

## What this does not cover

The walk takes one path: no existing instance, not a Raspberry Pi, not a satellite profile. The satellite and tuning branches, and the existing-instance uninstall prompt, are still only covered per screen. Worth extending later; this covers the path every ordinary install takes.

473 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for the installer’s interactive setup flow under stricter environment conditions.
  * Verified that the TUI completes successfully on a standard machine, selects valid defaults, and produces the required installation settings.
  * Updated test execution to better match the installer’s runtime behavior, improving confidence that setup screens handle unset values reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->