### PR TITLE
Pin ovos-docker to release v2.0.0

### DIFF
--- a/ansible/roles/ovos_installer/defaults/main.yml
+++ b/ansible/roles/ovos_installer/defaults/main.yml
@@ -63,7 +63,7 @@ ovos_installer_xhost_package_default: xorg-x11-server-utils
 ovos_installer_x11_xserver_utils_package: x11-xserver-utils
 ovos_installer_ovos_docker_repo_url: https://github.com/OpenVoiceOS/ovos-docker.git
 # Pinned to an ovos-docker release so containers-mode installs are reproducible; bump on new releases.
-ovos_installer_ovos_docker_repo_branch: v2.0.1
+ovos_installer_ovos_docker_repo_branch: v2.0.2
 ovos_installer_hivemind_docker_repo_url: https://github.com/JarbasHiveMind/hivemind-docker.git
 ovos_installer_hivemind_docker_repo_branch: feat/initial
 ovos_installer_docker_image_tag: "{{ ovos_installer_channel | default('testing') }}"

--- a/ansible/roles/ovos_installer/defaults/main.yml
+++ b/ansible/roles/ovos_installer/defaults/main.yml
@@ -62,7 +62,8 @@ ovos_installer_xhost_package_fedora: xhost
 ovos_installer_xhost_package_default: xorg-x11-server-utils
 ovos_installer_x11_xserver_utils_package: x11-xserver-utils
 ovos_installer_ovos_docker_repo_url: https://github.com/OpenVoiceOS/ovos-docker.git
-ovos_installer_ovos_docker_repo_branch: dev
+# Pinned to an ovos-docker release so containers-mode installs are reproducible; bump on new releases.
+ovos_installer_ovos_docker_repo_branch: v2.0.0
 ovos_installer_hivemind_docker_repo_url: https://github.com/JarbasHiveMind/hivemind-docker.git
 ovos_installer_hivemind_docker_repo_branch: feat/initial
 ovos_installer_docker_image_tag: "{{ ovos_installer_channel | default('testing') }}"

--- a/ansible/roles/ovos_installer/defaults/main.yml
+++ b/ansible/roles/ovos_installer/defaults/main.yml
@@ -63,7 +63,7 @@ ovos_installer_xhost_package_default: xorg-x11-server-utils
 ovos_installer_x11_xserver_utils_package: x11-xserver-utils
 ovos_installer_ovos_docker_repo_url: https://github.com/OpenVoiceOS/ovos-docker.git
 # Pinned to an ovos-docker release so containers-mode installs are reproducible; bump on new releases.
-ovos_installer_ovos_docker_repo_branch: v2.0.0
+ovos_installer_ovos_docker_repo_branch: v2.0.1
 ovos_installer_hivemind_docker_repo_url: https://github.com/JarbasHiveMind/hivemind-docker.git
 ovos_installer_hivemind_docker_repo_branch: feat/initial
 ovos_installer_docker_image_tag: "{{ ovos_installer_channel | default('testing') }}"

--- a/ansible/roles/ovos_installer/defaults/main.yml
+++ b/ansible/roles/ovos_installer/defaults/main.yml
@@ -65,7 +65,7 @@ ovos_installer_ovos_docker_repo_url: https://github.com/OpenVoiceOS/ovos-docker.
 # Pinned to an ovos-docker release so containers-mode installs are reproducible; bump on new releases.
 ovos_installer_ovos_docker_repo_branch: v2.0.2
 ovos_installer_hivemind_docker_repo_url: https://github.com/JarbasHiveMind/hivemind-docker.git
-ovos_installer_hivemind_docker_repo_branch: feat/initial
+ovos_installer_hivemind_docker_repo_branch: v2.0.0
 ovos_installer_docker_image_tag: "{{ ovos_installer_channel | default('testing') }}"
 ovos_installer_docker_pull_policy: always
 ovos_installer_docker_compose_remove_orphans: true


### PR DESCRIPTION
ovos-docker now publishes releases following the same milestone theme ([v2.0.0 — Lemmings](https://github.com/OpenVoiceOS/ovos-docker/releases/tag/v2.0.0), [v1.0.0 — Tetris](https://github.com/OpenVoiceOS/ovos-docker/releases/tag/v1.0.0)). Pinning `ovos_installer_ovos_docker_repo_branch` to the release tag makes containers-mode installs reproducible: a change on ovos-docker's `dev` can no longer alter what an install deploys. Bump the pin when ovos-docker releases.

Trade-off to be aware of: compose-file fixes on `dev` only reach installs after a new ovos-docker release + pin bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated container-based installations to use the ovos-docker 2.0.2 release by default, improving consistency and reproducibility during setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

**Also pins `ovos_installer_hivemind_docker_repo_branch: v2.0.0`** (was `feat/initial`): [hivemind-docker v2.0.0 — SimAnt](https://github.com/JarbasHiveMind/hivemind-docker/releases/tag/v2.0.0) now follows the same release convention and CI as ovos-docker — constraints-pinned images per channel, verified/signed publishes, hardened compose. The ovos-docker pin is [v2.0.2](https://github.com/OpenVoiceOS/ovos-docker/releases/tag/v2.0.2) (restores image signatures and the collision-proof GHCR mirror). Bump both on each container-repo release.