### PR TITLE
fix(containers): never let the repository clone stop on a credential prompt

### DIFF
--- a/ansible/roles/ovos_containers/tasks/common.yml
+++ b/ansible/roles/ovos_containers/tasks/common.yml
@@ -54,6 +54,15 @@
     version: "{{ item.branch }}"
     update: "{{ _repo_update_required | bool }}"
     force: "{{ ovos_containers_repo_force_checkout | bool }}"
+  environment:
+    # Both repositories are public, so git never needs credentials. Should the URL
+    # answer 401/404 anyway (an overridden fork, a proxy or DNS filter intercepting
+    # github.com), git would ask for a username on the terminal and the installer
+    # would sit there forever; these make it fail immediately with that reason
+    # instead. Credential helpers are still consulted, so a private fork configured
+    # with one keeps working.
+    GIT_TERMINAL_PROMPT: "0"
+    GIT_ASKPASS: ""
   loop: "{{ ovos_containers_repo_definitions }}"
   loop_control:
     label: "{{ item.dest }}"


### PR DESCRIPTION
## Symptom

Reported by @JoergZ2 — the installer stops at this step and waits, forever:

```
TASK [ovos_containers : Clone ovos-docker and/or hivemind-docker repository] ***
Username for 'https://github.com':
```

## What I checked first

Both repositories are public and nothing in the installer points anywhere else, so this is **not** the pinned refs and not a repository that needs credentials. Verified anonymously (no credential helper, prompts disabled):

- `ovos-docker` and `hivemind-docker` resolve, including every tag; `dev` and `feat/initial` still exist
- a fresh recursive clone at `v2.0.2` / `v2.0.0` succeeds
- **updating** an existing checkout from the old pins (`dev`, `feat/initial`) to the new tags succeeds
- a leftover clone in `/tmp` whose `origin` points at a dead URL is repaired by the module, not fetched from
- stale stored credentials are *not* the cause: git only authenticates after a 401, so a public repo never consults the helper

Git asks for a username in exactly one situation: the URL answered **401/404**. Since the canonical URLs answer 200 anonymously, the reporter's git is reaching something else — an overridden repo URL, or a proxy/DNS filter that intercepts `github.com`.

## The fix

Whatever the cause, the installer must not sit on an invisible prompt. With `GIT_TERMINAL_PROMPT=0` and an empty `GIT_ASKPASS` (which also neutralises an inherited GUI askpass or `SSH_ASKPASS`), the same situation now fails in seconds, saying why:

```
fatal: could not read Username for 'https://github.com': terminal prompts disabled
```

Credential helpers are still consulted, so anyone pointing `ovos_installer_*_repo_url` at a private fork keeps cloning non-interactively.

## Verification

Ran the real module locally: the public clone at the pinned tag still succeeds, and an unreachable URL fails after ~4s instead of hanging. `ansible-lint` (production profile) and `yamllint` with `ansible/.yamllint` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Repository setup now fails promptly when authentication or access errors occur, instead of waiting for terminal input.
  * Configured credential helpers continue to support access to private repositories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->