### PR TITLE
fix(virtualenv): install the VAD fallback plugin so the listener can start

### DIFF
--- a/ansible/roles/ovos_virtualenv/templates/virtualenv/core-requirements.txt.j2
+++ b/ansible/roles/ovos_virtualenv/templates/virtualenv/core-requirements.txt.j2
@@ -4,13 +4,21 @@
 ovos-audio[extras]
 ovos-core[lgpl,plugins]
 ovos-dinkum-listener[{{ 'extras' if ansible_facts.system == 'Darwin' else 'extras,linux' }}]
-# Keep configured VAD selection and Linux fallback installed explicitly.
+# Keep configured VAD selection and its fallback installed explicitly.
 {% if (ovos_installer_cpu_is_capable | default(false)) | bool %}
 ovos-vad-plugin-silero
 {% endif %}
 {% if ansible_facts.system != 'Darwin' %}
 ovos-vad-plugin-webrtcvad
 {% endif %}
+# OVOSVADFactory falls back to this plugin when the configured one fails to
+# load. ovos-dinkum-listener used to pull it in through [extras] and no longer
+# does, so install it here: without it a VAD failure is fatal to the listener.
+ovos-vad-plugin-noise
+# ovos-plugin-manager and webrtcvad import pkg_resources, which setuptools 82
+# removed and Python no longer ships. Pinning the ceiling here enforces it on
+# every run, not only when the venv is first bootstrapped.
+{{ ovos_virtualenv_setuptools_package }}
 {% if ansible_facts.system == 'Darwin' or _ovos_is_mark2_family %}
 ovos-microphone-plugin-sounddevice
 {% endif %}

--- a/ansible/roles/ovos_virtualenv/templates/virtualenv/satellite-requirements.txt.j2
+++ b/ansible/roles/ovos_virtualenv/templates/virtualenv/satellite-requirements.txt.j2
@@ -4,13 +4,21 @@ hivemind-bus-client
 hivemind-voice-sat
 ovos-audio[extras]
 ovos-dinkum-listener[{{ 'extras' if ansible_facts.system == 'Darwin' else 'extras,linux' }}]
-# Keep configured VAD selection and Linux fallback installed explicitly.
+# Keep configured VAD selection and its fallback installed explicitly.
 {% if (ovos_installer_cpu_is_capable | default(false)) | bool %}
 ovos-vad-plugin-silero
 {% endif %}
 {% if ansible_facts.system != 'Darwin' %}
 ovos-vad-plugin-webrtcvad
 {% endif %}
+# OVOSVADFactory falls back to this plugin when the configured one fails to
+# load. ovos-dinkum-listener used to pull it in through [extras] and no longer
+# does, so install it here: without it a VAD failure is fatal to the listener.
+ovos-vad-plugin-noise
+# ovos-plugin-manager and webrtcvad import pkg_resources, which setuptools 82
+# removed and Python no longer ships. Pinning the ceiling here enforces it on
+# every run, not only when the venv is first bootstrapped.
+{{ ovos_virtualenv_setuptools_package }}
 {% if ansible_facts.system == 'Darwin' or _ovos_is_mark2_family %}
 ovos-microphone-plugin-sounddevice
 {% endif %}


### PR DESCRIPTION
## Symptom

`ovos-dinkum-listener` dies at startup, taking the voice service with it:

```
WARNING - Could not find the plugin PluginTypes.VAD.ovos-vad-plugin-webrtcvad
ERROR - VAD plugin ovos-vad-plugin-webrtcvad could not be loaded!
TypeError: 'NoneType' object is not callable
INFO - Attempting to load fallback plugin instead: ovos-vad-plugin-noise
WARNING - Could not find the plugin PluginTypes.VAD.ovos-vad-plugin-noise
ERROR - VAD plugin ovos-vad-plugin-noise could not be loaded!
```

## Root cause

`OVOSVADFactory.create()` catches a failing VAD plugin and retries with the configured `fallback_module`, `ovos-vad-plugin-noise`. **Nothing in this repository installs that plugin**, and it used to arrive for free through the listener's extras — which upstream changed:

| `ovos-dinkum-listener` | what `[extras]` provides |
| --- | --- |
| 0.4.1 | `ovos-vad-plugin-noise` ✅ (plus precise-lite, stt-chromium) |
| 0.9.0a1 | `ovos-vad-plugin-silero` — **noise is gone**; `webrtcvad` now only in the `tests` extra |

So on a current install the fallback simply does not exist, and any VAD load failure is fatal instead of degrading. On hosts where `ovos_installer_cpu_is_capable` is false we configure `ovos-vad-plugin-webrtcvad` (silero needs a capable CPU), which is precisely the case with no safety net left.

## Changes

Both venv requirement sets (`core`, `satellite`) now install:

- **`ovos-vad-plugin-noise`** — pure-Python, wheels for 3.13, so the documented fallback is always present and a VAD failure degrades instead of killing the listener.
- **`{{ ovos_virtualenv_setuptools_package }}`** (`setuptools<82`) — `ovos-plugin-manager` and `webrtcvad` both `import pkg_resources`, which setuptools 82 removed and Python no longer ships. The ceiling was only applied by the *bootstrap* task, which is skipped whenever `{{ venv }}/bin/pip` already exists, so a re-run could leave the venv without it; declaring it in the requirements enforces it on every run.

## Verification

On Python 3.13: `import webrtcvad` fails with `ModuleNotFoundError: pkg_resources` in a bare venv and succeeds once `setuptools<82` is installed; `OVOSVADFactory.create({'module': 'ovos-vad-plugin-noise'})` returns `NoiseVAD`. Both templates were rendered for the affected path (Linux, non-capable CPU) and the resulting set resolves against `constraints-alpha.txt` with no conflicts.

## For the reporter

This stops the crash, but it is worth knowing why the *configured* plugin was missing too — on the affected host:

```bash
/home/ovos/.venv/bin/pip list | grep -Ei 'vad|setuptools'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved voice activity detection fallback behavior when the configured plugin cannot load.
  * Prevented compatibility issues caused by newer setuptools versions, helping preserve audio plugin functionality.
* **Reliability**
  * Ensured required fallback audio components are installed consistently in both core and satellite virtual environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->