### PR TITLE
fix(containers): remove the images the uninstall leaves behind

### DIFF
--- a/ansible/roles/ovos_containers/defaults/main.yml
+++ b/ansible/roles/ovos_containers/defaults/main.yml
@@ -139,12 +139,30 @@ ovos_containers_uninstall_compose_files_ovos:
   - "{{ ovos_containers_compose_file_windows }}"
 ovos_containers_uninstall_compose_files_hivemind:
   - "{{ ovos_containers_compose_file_satellite }}"
+# docker-compose project names used by older releases of the installer, they
+# are kept around to clean up legacy installations.
+ovos_containers_uninstall_legacy_project_name_ovos: ovos-docker
+ovos_containers_uninstall_legacy_project_name_hivemind: hivemind-docker
 ovos_containers_uninstall_project_names:
   - "{{ ovos_containers_uninstall_project_name_ovos }}"
   - "{{ ovos_containers_uninstall_project_name_hivemind }}"
+  - "{{ ovos_containers_uninstall_legacy_project_name_ovos }}"
+  - "{{ ovos_containers_uninstall_legacy_project_name_hivemind }}"
 ovos_containers_uninstall_name_prefixes:
   - "{{ ovos_containers_uninstall_project_name_ovos }}_"
   - "{{ ovos_containers_uninstall_project_name_hivemind }}_"
+# Containers, images, volumes and networks whose name matches one of these
+# patterns are never removed by the uninstall cleanup, even when they carry a
+# docker-compose project label of this installer. STT/TTS servers are not
+# deployed by the installer, they are managed by the user, but they commonly
+# use an "ovos_" name prefix.
+ovos_containers_uninstall_name_excludes: >-
+  {{ ovos_installer_uninstall_name_excludes | default(['ovos_stt', 'ovos_tts']) }}
+# Remove the images backing the removed containers. Follows the docker-compose
+# "remove_images" setting so both removal paths behave the same way.
+ovos_containers_uninstall_remove_images: >-
+  {{ (ovos_containers_docker_compose_remove_images | string) not in ['', 'none', 'false', 'False'] }}
+ovos_containers_uninstall_compose_project_label: com.docker.compose.project
 ovos_containers_remove_directories:
   - "{{ ovos_containers_ovos_base_dir }}"
   - "{{ ovos_containers_hivemind_base_dir }}"

--- a/ansible/roles/ovos_containers/tasks/uninstall.yml
+++ b/ansible/roles/ovos_containers/tasks/uninstall.yml
@@ -93,24 +93,30 @@
       {% if excludes | length > 0 %}
       {% set exclude_re = '^/?(' ~ (excludes | map('regex_escape') | join('|')) ~ ')' %}
       {% endif %}
-      {% set ns = namespace(ids=[], images=[], kept_images=[]) %}
+      {% set ns = namespace(ids=[], targets=[], kept_image_ids=[], kept_image_refs=[], images=[]) %}
       {% for c in (ovos_containers_host_info.containers | default([])) %}
       {% set names = c.Names | default([]) %}
       {% set labels = c.Labels | default({}) or {} %}
       {% set project = labels.get(ovos_containers_uninstall_compose_project_label, '') %}
-      {% set image = (c.Image | default('')) or (c.ImageID | default('')) %}
+      {% set image_ref = (c.Image | default('')) or (c.ImageID | default('')) %}
+      {% set image_id = (c.ImageID | default('')) or (c.Image | default('')) %}
       {% set match_project = (projects | length > 0 and project | length > 0 and project in projects) %}
       {% set match_prefix = (prefix_re | length > 0 and (names | select('match', prefix_re) | list | length > 0)) %}
       {% set excluded = (exclude_re | length > 0 and (names | select('match', exclude_re) | list | length > 0)) %}
       {% if (match_project or match_prefix) and not excluded %}
       {% set _ = ns.ids.append(c.Id) %}
-      {% if image | length > 0 %}{% set _ = ns.images.append(image) %}{% endif %}
-      {% elif image | length > 0 %}
-      {% set _ = ns.kept_images.append(image) %}
+      {% if image_ref | length > 0 %}{% set _ = ns.targets.append([image_id, image_ref]) %}{% endif %}
+      {% else %}
+      {% if image_id | length > 0 %}{% set _ = ns.kept_image_ids.append(image_id) %}{% endif %}
+      {% if image_ref | length > 0 %}{% set _ = ns.kept_image_refs.append(image_ref) %}{% endif %}
       {% endif %}
       {% endfor %}
-      {{ {'ids': ns.ids | unique | list,
-          'images': ns.images | unique | difference(ns.kept_images | unique) | list} }}
+      {% for target in ns.targets %}
+      {% if target[0] not in ns.kept_image_ids and target[1] not in ns.kept_image_refs %}
+      {% set _ = ns.images.append(target[1]) %}
+      {% endif %}
+      {% endfor %}
+      {{ {'ids': ns.ids | unique | list, 'images': ns.images | unique | list} }}
   ansible.builtin.set_fact:
     ovos_containers_uninstall_target_ids: "{{ (_ovos_containers_uninstall_selection_raw | from_yaml).ids }}"
     ovos_containers_uninstall_target_images: "{{ (_ovos_containers_uninstall_selection_raw | from_yaml).images }}"
@@ -163,8 +169,11 @@
   loop: "{{ ovos_containers_uninstall_target_ids | default([]) }}"
   when: ovos_containers_uninstall_target_ids | default([]) | length > 0
 
-# A leftover image is not worth failing the uninstall for, it can still be
-# referenced by another repository/tag or by a container created in between.
+# Removal uses the image reference the container was created from, so only that
+# reference is untagged, but an image is retained by ID as well as by reference,
+# because a container which stays can hold the same image under a different
+# reference. A leftover image is not worth failing the uninstall for either, it
+# can still be referenced by another tag or by a container created in between.
 - name: Remove container images
   become: true
   community.docker.docker_image_remove:

--- a/ansible/roles/ovos_containers/tasks/uninstall.yml
+++ b/ansible/roles/ovos_containers/tasks/uninstall.yml
@@ -59,38 +59,98 @@
     - ovos_containers_docker_socket_stat.stat.exists | default(false) | bool
     - ovos_containers_compose_project_stat_hivemind.stat.isdir | default(false) | bool
 
-- name: List all containers
+# The docker-compose removal above is skipped when the composition directories
+# are gone (they live under a temporary directory which is wiped on reboot on
+# most distributions), so leftovers are collected and removed by label/name to
+# make this path equivalent to "docker compose down --rmi all --volumes",
+# minus the objects protected by "ovos_containers_uninstall_name_excludes"
+# (user managed STT/TTS servers and their images and volumes).
+# "verbose_output" is required, without it the objects are returned without
+# their labels and the docker-compose project cannot be identified.
+- name: List all containers, networks and volumes
   become: true
   community.docker.docker_host_info:
     containers: true
     containers_all: true
+    networks: true
+    volumes: true
+    verbose_output: true
   register: ovos_containers_host_info
   failed_when: ovos_containers_host_info is failed
   when: ovos_containers_docker_socket_stat.stat.exists | default(false) | bool
 
-- name: Select containers to remove
+- name: Select containers and images to remove
   vars:
-    _ovos_containers_uninstall_target_ids_raw: >-
+    _ovos_containers_uninstall_selection_raw: >-
       {% set prefixes = ovos_containers_uninstall_name_prefixes | default([]) %}
       {% set projects = ovos_containers_uninstall_project_names | default([]) %}
+      {% set excludes = ovos_containers_uninstall_name_excludes | default([]) %}
       {% set prefix_re = '' %}
       {% if prefixes | length > 0 %}
       {% set prefix_re = '^/?(' ~ (prefixes | map('regex_escape') | join('|')) ~ ')' %}
       {% endif %}
-      {% set ns = namespace(ids=[]) %}
+      {% set exclude_re = '' %}
+      {% if excludes | length > 0 %}
+      {% set exclude_re = '^/?(' ~ (excludes | map('regex_escape') | join('|')) ~ ')' %}
+      {% endif %}
+      {% set ns = namespace(ids=[], images=[], kept_images=[]) %}
       {% for c in (ovos_containers_host_info.containers | default([])) %}
       {% set names = c.Names | default([]) %}
-      {% set labels = c.Labels | default({}) %}
-      {% set project = labels.get('com.docker.compose.project', '') %}
+      {% set labels = c.Labels | default({}) or {} %}
+      {% set project = labels.get(ovos_containers_uninstall_compose_project_label, '') %}
+      {% set image = (c.Image | default('')) or (c.ImageID | default('')) %}
       {% set match_project = (projects | length > 0 and project | length > 0 and project in projects) %}
       {% set match_prefix = (prefix_re | length > 0 and (names | select('match', prefix_re) | list | length > 0)) %}
-      {% if match_project or match_prefix %}
+      {% set excluded = (exclude_re | length > 0 and (names | select('match', exclude_re) | list | length > 0)) %}
+      {% if (match_project or match_prefix) and not excluded %}
       {% set _ = ns.ids.append(c.Id) %}
+      {% if image | length > 0 %}{% set _ = ns.images.append(image) %}{% endif %}
+      {% elif image | length > 0 %}
+      {% set _ = ns.kept_images.append(image) %}
       {% endif %}
       {% endfor %}
-      {{ ns.ids | unique | list }}
+      {{ {'ids': ns.ids | unique | list,
+          'images': ns.images | unique | difference(ns.kept_images | unique) | list} }}
   ansible.builtin.set_fact:
-    ovos_containers_uninstall_target_ids: "{{ _ovos_containers_uninstall_target_ids_raw | from_yaml }}"
+    ovos_containers_uninstall_target_ids: "{{ (_ovos_containers_uninstall_selection_raw | from_yaml).ids }}"
+    ovos_containers_uninstall_target_images: "{{ (_ovos_containers_uninstall_selection_raw | from_yaml).images }}"
+  when: ovos_containers_host_info is defined
+
+- name: Select networks and volumes to remove
+  vars:
+    _ovos_containers_uninstall_exclude_re: >-
+      {{
+        ('^/?(' ~ (ovos_containers_uninstall_name_excludes | map('regex_escape') | join('|')) ~ ')')
+        if (ovos_containers_uninstall_name_excludes | default([]) | length > 0)
+        else ''
+      }}
+    _ovos_containers_uninstall_networks_raw: >-
+      {% set projects = ovos_containers_uninstall_project_names | default([]) %}
+      {% set exclude_re = _ovos_containers_uninstall_exclude_re | trim %}
+      {% set ns = namespace(names=[]) %}
+      {% for n in (ovos_containers_host_info.networks | default([])) %}
+      {% set labels = n.Labels | default({}) or {} %}
+      {% set excluded = exclude_re | length > 0 and n.Name is match(exclude_re) %}
+      {% if labels.get(ovos_containers_uninstall_compose_project_label, '') in projects and not excluded %}
+      {% set _ = ns.names.append(n.Name) %}
+      {% endif %}
+      {% endfor %}
+      {{ ns.names | unique | list }}
+    _ovos_containers_uninstall_volumes_raw: >-
+      {% set projects = ovos_containers_uninstall_project_names | default([]) %}
+      {% set exclude_re = _ovos_containers_uninstall_exclude_re | trim %}
+      {% set ns = namespace(names=[]) %}
+      {% for v in (ovos_containers_host_info.volumes | default([])) %}
+      {% set labels = v.Labels | default({}) or {} %}
+      {% set excluded = exclude_re | length > 0 and v.Name is match(exclude_re) %}
+      {% if labels.get(ovos_containers_uninstall_compose_project_label, '') in projects and not excluded %}
+      {% set _ = ns.names.append(v.Name) %}
+      {% endif %}
+      {% endfor %}
+      {{ ns.names | unique | list }}
+  ansible.builtin.set_fact:
+    ovos_containers_uninstall_target_networks: "{{ _ovos_containers_uninstall_networks_raw | from_yaml }}"
+    ovos_containers_uninstall_target_volumes: "{{ _ovos_containers_uninstall_volumes_raw | from_yaml }}"
   when: ovos_containers_host_info is defined
 
 - name: Remove containers
@@ -102,6 +162,37 @@
     keep_volumes: "{{ not (ovos_containers_docker_compose_remove_volumes | bool) }}"
   loop: "{{ ovos_containers_uninstall_target_ids | default([]) }}"
   when: ovos_containers_uninstall_target_ids | default([]) | length > 0
+
+# A leftover image is not worth failing the uninstall for, it can still be
+# referenced by another repository/tag or by a container created in between.
+- name: Remove container images
+  become: true
+  community.docker.docker_image_remove:
+    name: "{{ item }}"
+  loop: "{{ ovos_containers_uninstall_target_images | default([]) }}"
+  register: ovos_containers_image_deletion
+  failed_when: false
+  when:
+    - ovos_containers_uninstall_remove_images | bool
+    - ovos_containers_uninstall_target_images | default([]) | length > 0
+
+- name: Remove volumes
+  become: true
+  community.docker.docker_volume:
+    name: "{{ item }}"
+    state: absent
+  loop: "{{ ovos_containers_uninstall_target_volumes | default([]) }}"
+  when:
+    - ovos_containers_docker_compose_remove_volumes | bool
+    - ovos_containers_uninstall_target_volumes | default([]) | length > 0
+
+- name: Remove networks
+  become: true
+  community.docker.docker_network:
+    name: "{{ item }}"
+    state: absent
+  loop: "{{ ovos_containers_uninstall_target_networks | default([]) }}"
+  when: ovos_containers_uninstall_target_networks | default([]) | length > 0
 
 - name: Check for cmdline.txt (cgroup cleanup)
   ansible.builtin.stat:


### PR DESCRIPTION
Suggested by @JoergZ2 in #579.

## Symptom

Uninstall removes the OVOS and HiveMind containers but the images stay on disk, along with the compose volumes and networks.

## Root cause

Two things, both in `ovos_containers/tasks/uninstall.yml`:

- The docker-compose removal already passes `remove_images: all` and `remove_volumes: true`, but it is gated on a `stat` of the composition directory. That directory lives under `/tmp`, uninstall never re-clones it, and a previous uninstall deletes it. So after a reboot both compose tasks are skipped and only the fallback runs, which removes containers and nothing else.
- The fallback's docker-compose project match could never fire. `docker_host_info` only returns labels with `verbose_output: true`, so `c.Labels` was always empty and the name prefix rule was doing all the work.

## Changes

- List networks and volumes as well, with `verbose_output: true` so the labels are actually there.
- Remove the images backing the containers we remove, then the project's volumes and networks. The fallback now ends where `docker compose down --rmi all --volumes` would.
- An image still used by a container we are not removing is left alone.
- `ovos_containers_uninstall_name_excludes` (default `ovos_stt`, `ovos_tts`) protects a name from all of it, label or no label, including its image and volumes. We do not deploy STT or TTS servers, so those belong to the user. Override with `-e ovos_installer_uninstall_name_excludes='["ovos_whisper"]'` for other names.
- Legacy `ovos-docker` / `hivemind-docker` project names are cleaned up too.

## Verification

`ansible-lint` clean on the production profile, `yamllint` clean, `--syntax-check` passes for the `ovos` and `satellite` profiles with `cleaning=true`.

Ran the real tasks against a live daemon with fixtures for every branch: containers matched by label, by prefix only (legacy install), an `ovos_stt_server` **carrying** `com.docker.compose.project=ovos`, an unlabelled `ovos_tts_server`, an image shared with a container we do not own, and labelled networks and volumes on both sides of the exclusion.

Removed: 4 containers, their 2 images, `ovos_testnet`, `ovos_testvol`.
Untouched: both STT/TTS containers and their images, the shared image, `ovos_tts_net`, `ovos_stt_models`.

One thing the exclusion cannot cover: if an STT service is declared inside the OVOS compose file and the composition directory is still there, `docker compose down --rmi all` takes it before we get a say. Separate containers, the normal case, are safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved uninstall cleanup to remove containers, networks, volumes, and images from current and legacy installations.
  * Preserves excluded services, including speech-to-text and text-to-speech components.
  * Prevents removal of images still used by other containers.
  * Makes image cleanup behavior configurable and tolerates image-removal failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->