### PR TITLE
Run the Ansible playbook through Mitogen where it is supported

### DIFF
--- a/.github/workflows/scenarios-ubuntu2404.yml
+++ b/.github/workflows/scenarios-ubuntu2404.yml
@@ -70,6 +70,14 @@ jobs:
         method:
           - virtualenv
           - containers
+        # The whole matrix runs through Mitogen, because that is the default.
+        # One entry opts out so the fallback keeps being a real install rather
+        # than a code path nobody runs, and so a regression that only appears
+        # under Mitogen can be told apart from one that does not.
+        include:
+          - runner: ubuntu-24.04
+            method: virtualenv
+            mitogen: "false"
 
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 90
@@ -78,6 +86,7 @@ jobs:
       CI_HOMEASSISTANT_URL: http://homeassistant.local:8123
       CI_HOMEASSISTANT_API_KEY: ci-token
       OVOS_CI_MAX_INSTALL_SECONDS: "2400"
+      OVOS_INSTALLER_MITOGEN: ${{ matrix.mitogen || 'true' }}
 
     steps:
       - name: Checkout code
@@ -150,6 +159,7 @@ jobs:
           sudo -E env \
             ANSIBLE_CALLBACKS_ENABLED="profile_tasks,timer" \
             REUSE_CACHED_ARTIFACTS=true \
+            OVOS_INSTALLER_MITOGEN="${OVOS_INSTALLER_MITOGEN:-true}" \
             bash setup.sh
 
           elapsed="$(( $(date +%s) - start_ts ))"
@@ -178,7 +188,7 @@ jobs:
           EOF
 
       - name: Run uninstall scenario smoke
-        run: sudo -E env REUSE_CACHED_ARTIFACTS=true bash setup.sh
+        run: sudo -E env REUSE_CACHED_ARTIFACTS=true OVOS_INSTALLER_MITOGEN="${OVOS_INSTALLER_MITOGEN:-true}" bash setup.sh
 
       - name: Dump diagnostics on failure
         if: failure()
@@ -310,11 +320,15 @@ jobs:
               HOMEASSISTANT_API_KEY="${CI_HOMEASSISTANT_API_KEY}" \
               ANSIBLE_CALLBACKS_ENABLED="profile_tasks,timer" \
               REUSE_CACHED_ARTIFACTS=true \
+              OVOS_INSTALLER_MITOGEN="${OVOS_INSTALLER_MITOGEN:-true}" \
+            OVOS_INSTALLER_MITOGEN="${OVOS_INSTALLER_MITOGEN:-true}" \
               bash setup.sh
           else
             sudo -E env \
               ANSIBLE_CALLBACKS_ENABLED="profile_tasks,timer" \
               REUSE_CACHED_ARTIFACTS=true \
+              OVOS_INSTALLER_MITOGEN="${OVOS_INSTALLER_MITOGEN:-true}" \
+            OVOS_INSTALLER_MITOGEN="${OVOS_INSTALLER_MITOGEN:-true}" \
               bash setup.sh
           fi
 
@@ -344,7 +358,7 @@ jobs:
           EOF
 
       - name: Run uninstall scenario exhaustive
-        run: sudo -E env REUSE_CACHED_ARTIFACTS=true bash setup.sh
+        run: sudo -E env REUSE_CACHED_ARTIFACTS=true OVOS_INSTALLER_MITOGEN="${OVOS_INSTALLER_MITOGEN:-true}" bash setup.sh
 
       - name: Dump diagnostics on failure
         if: failure()
@@ -473,10 +487,10 @@ jobs:
           EOF
 
       - name: Run uninstall pass 1
-        run: sudo -E env REUSE_CACHED_ARTIFACTS=true bash setup.sh
+        run: sudo -E env REUSE_CACHED_ARTIFACTS=true OVOS_INSTALLER_MITOGEN="${OVOS_INSTALLER_MITOGEN:-true}" bash setup.sh
 
       - name: Run uninstall pass 2
-        run: sudo -E env REUSE_CACHED_ARTIFACTS=true bash setup.sh
+        run: sudo -E env REUSE_CACHED_ARTIFACTS=true OVOS_INSTALLER_MITOGEN="${OVOS_INSTALLER_MITOGEN:-true}" bash setup.sh
 
       - name: Dump diagnostics on failure
         if: failure()
@@ -620,7 +634,7 @@ jobs:
           EOF
 
       - name: Run uninstall cleanup
-        run: sudo -E env REUSE_CACHED_ARTIFACTS=true bash setup.sh
+        run: sudo -E env REUSE_CACHED_ARTIFACTS=true OVOS_INSTALLER_MITOGEN="${OVOS_INSTALLER_MITOGEN:-true}" bash setup.sh
 
       - name: Dump diagnostics on failure
         if: failure()
@@ -735,7 +749,7 @@ jobs:
         shell: bash
         run: |
           set +e
-          sudo -E env REUSE_CACHED_ARTIFACTS=true bash setup.sh
+          sudo -E env REUSE_CACHED_ARTIFACTS=true OVOS_INSTALLER_MITOGEN="${OVOS_INSTALLER_MITOGEN:-true}" bash setup.sh
           rc=$?
           set -e
           if [ "$rc" -eq 0 ]; then

--- a/README.md
+++ b/README.md
@@ -58,9 +58,26 @@ sudo env OVOS_VENV_PYTHON=3.12 sh -c "$(curl -fsSL https://raw.githubusercontent
 # Speed up repeated runs by reusing cached artifacts (useful for debugging)
 sudo env REUSE_CACHED_ARTIFACTS=true sh -c "$(curl -fsSL https://raw.githubusercontent.com/OpenVoiceOS/ovos-installer/main/installer.sh)"
 
+# Run the playbook on Ansible's own strategy instead of Mitogen
+sudo env OVOS_INSTALLER_MITOGEN=false sh -c "$(curl -fsSL https://raw.githubusercontent.com/OpenVoiceOS/ovos-installer/main/installer.sh)"
+
 # Forward proxy variables into generated launchd/systemd services
 sudo env HTTPS_PROXY=http://proxy.example:3128 HTTP_PROXY=http://proxy.example:3128 NO_PROXY=localhost,127.0.0.1 sh -c "$(curl -fsSL https://raw.githubusercontent.com/OpenVoiceOS/ovos-installer/main/installer.sh)"
 ```
+
+### Install speed
+
+The playbook runs through [Mitogen](https://mitogen.networkgenomics.com/ansible_detailed.html),
+which keeps one Python interpreter alive for the whole run instead of starting
+a new one per task. On a local run that is worth roughly four times less CPU
+spent on task overhead, which matters most on a Raspberry Pi, where that
+overhead is a real part of the install rather than a rounding error.
+
+It is used only where it is supported — Python 3.11 or newer, which is what
+Mitogen supports for the pinned Ansible version — and the installer falls back
+to Ansible's own strategy on older interpreters, or if the package cannot be
+loaded, without failing the install. `OVOS_INSTALLER_MITOGEN=false` turns it
+off, which is the first thing to try if a run behaves oddly.
 
 Guide: [Begin your Open Voice OS journey with the OVOS installer](https://community.openconversational.ai/t/howto-begin-your-open-voice-os-journey-with-the-ovos-installer/14900)
 

--- a/setup.sh
+++ b/setup.sh
@@ -153,6 +153,11 @@ case "${DISTRO_NAME:-}" in
     ;;
 esac
 export ANSIBLE_NOCOWS=1
+
+# After ANSIBLE_PYTHON_INTERPRETER: Mitogen starts the interpreter chosen
+# above and keeps it, so the strategy is only decided once that is settled.
+configure_ansible_strategy
+
 if [ -t 1 ]; then
   unset ANSIBLE_NOCOLOR || true
   export ANSIBLE_FORCE_COLOR=true

--- a/tests/bats/mitogen.bats
+++ b/tests/bats/mitogen.bats
@@ -1,0 +1,131 @@
+#!/usr/bin/env bats
+#
+# Mitogen keeps one interpreter alive instead of starting a new one per task,
+# which is worth roughly 4x less CPU on the task overhead of a local run. It
+# only supports Ansible 10 on Python 3.11 and newer, though, and it works by
+# patching Ansible internals, so what matters here is that the installer is
+# strict about when it uses it and falls back rather than failing.
+
+function setup() {
+    load "$HOME/shell-testing/test_helper/bats-support/load"
+    load "$HOME/shell-testing/test_helper/bats-assert/load"
+
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    export REPO_ROOT
+    LOG_FILE="$(mktemp)"
+    export LOG_FILE
+}
+
+function teardown() {
+    rm -f "$LOG_FILE"
+}
+
+# The gate on its own, without needing Ansible installed.
+function gate() {
+    local python_version="$1"
+    local switch="$2"
+
+    bash -c '
+        cd "$REPO_ROOT"
+        set +u
+        ver() { printf "%03d" $(echo "$1" | tr "." " "); }
+        PYTHON="'"$python_version"'"
+        OVOS_INSTALLER_MITOGEN="'"$switch"'"
+        source <(sed -n "/^function mitogen_is_supported/,/^}/p" utils/common.sh)
+        if mitogen_is_supported; then printf mitogen; else printf stock; fi
+    '
+}
+
+@test "mitogen: used on the interpreters it supports" {
+    assert_equal "$(gate 3.11 true)" "mitogen"
+    assert_equal "$(gate 3.12 true)" "mitogen"
+    assert_equal "$(gate 3.14 true)" "mitogen"
+}
+
+@test "mitogen: not used below the version it supports Ansible 10 on" {
+    # The installer still runs on these, on Ansible's own strategy.
+    assert_equal "$(gate 3.10 true)" "stock"
+    assert_equal "$(gate 3.9 true)" "stock"
+}
+
+@test "mitogen: the kill switch wins over a supported interpreter" {
+    assert_equal "$(gate 3.12 false)" "stock"
+}
+
+@test "mitogen: an unknown interpreter is not assumed to be supported" {
+    assert_equal "$(gate "" true)" "stock"
+}
+
+@test "mitogen: the pin travels with the Ansible pin it patches" {
+    # Mitogen patches Ansible internals, so an unpinned pair would let a
+    # background upgrade of either one land on users unannounced.
+    run grep -E '^export MITOGEN_VERSION="[0-9]+\.[0-9]+\.[0-9]+"$' "$REPO_ROOT/utils/constants.sh"
+    assert_success
+
+    run grep -F -q 'mitogen==${MITOGEN_VERSION}' "$REPO_ROOT/utils/common.sh"
+    assert_success
+}
+
+@test "mitogen: a run that cannot import it still installs" {
+    # The speedup is worth having and never worth an install for, so an
+    # unloadable plugin has to leave the strategy alone rather than abort.
+    run bash -c '
+        cd "$REPO_ROOT"
+        set +u
+        ver() { printf "%03d" $(echo "$1" | tr "." " "); }
+        PYTHON="3.12"
+        OVOS_INSTALLER_MITOGEN="true"
+        VENV_PATH="$(mktemp -d)"
+        mkdir -p "$VENV_PATH/bin"
+        # An interpreter without the package installed.
+        printf "#!/bin/sh\nexit 1\n" >"$VENV_PATH/bin/python3"
+        chmod +x "$VENV_PATH/bin/python3"
+
+        source <(sed -n "/^function mitogen_is_supported/,/^}/p" utils/common.sh)
+        source <(sed -n "/^function configure_ansible_strategy/,/^}/p" utils/common.sh)
+
+        configure_ansible_strategy
+        printf "rc=%s strategy=%s\n" "$?" "${ANSIBLE_STRATEGY:-unset}"
+    '
+
+    assert_success
+    assert_output "rc=0 strategy=unset"
+}
+
+@test "mitogen: a working install is pointed at the strategy plugin" {
+    run bash -c '
+        cd "$REPO_ROOT"
+        set +u
+        ver() { printf "%03d" $(echo "$1" | tr "." " "); }
+        PYTHON="3.12"
+        OVOS_INSTALLER_MITOGEN="true"
+        VENV_PATH="$(mktemp -d)"
+        mkdir -p "$VENV_PATH/bin"
+        plugins="$(mktemp -d)/strategy"
+        mkdir -p "$plugins"
+        printf "#!/bin/sh\nprintf %%s \"%s\"\n" "$plugins" >"$VENV_PATH/bin/python3"
+        chmod +x "$VENV_PATH/bin/python3"
+
+        source <(sed -n "/^function mitogen_is_supported/,/^}/p" utils/common.sh)
+        source <(sed -n "/^function configure_ansible_strategy/,/^}/p" utils/common.sh)
+
+        configure_ansible_strategy
+        printf "%s|%s\n" "${ANSIBLE_STRATEGY:-unset}" "${ANSIBLE_STRATEGY_PLUGINS:+set}"
+    '
+
+    assert_success
+    assert_output "mitogen_linear|set"
+}
+
+@test "mitogen: the strategy is chosen after the interpreter it will start" {
+    # Mitogen starts ANSIBLE_PYTHON_INTERPRETER and keeps it, so deciding the
+    # strategy before that is settled would pin the wrong interpreter.
+    local file="$REPO_ROOT/setup.sh"
+
+    run bash -c "
+        interpreter=\$(grep -n 'ANSIBLE_PYTHON_INTERPRETER=' '$file' | tail -n1 | cut -d: -f1)
+        strategy=\$(grep -n 'configure_ansible_strategy' '$file' | head -n1 | cut -d: -f1)
+        [ -n \"\$interpreter\" ] && [ -n \"\$strategy\" ] && [ \"\$interpreter\" -lt \"\$strategy\" ]
+    "
+    assert_success
+}

--- a/utils/argparse.sh
+++ b/utils/argparse.sh
@@ -46,6 +46,14 @@ function handle_options() {
     # Always install and use uv instead of pip, which is significantly faster.
     export USE_UV="true"
 
+    # Run the playbook through Mitogen, which keeps one interpreter alive
+    # instead of starting a new one per task. Worth roughly 4x less CPU on the
+    # task overhead, which is what a Raspberry Pi spends most of its install
+    # budget on. Set OVOS_INSTALLER_MITOGEN=false to fall back to Ansible's
+    # own strategy; the installer already does that on its own wherever
+    # Mitogen is not supported or not importable.
+    export OVOS_INSTALLER_MITOGEN="${OVOS_INSTALLER_MITOGEN:-true}"
+
     # Keep cached installer artifacts by default to speed repeated runs.
     # Set REUSE_CACHED_ARTIFACTS=false for clean-room troubleshooting.
     export REUSE_CACHED_ARTIFACTS="${REUSE_CACHED_ARTIFACTS:-true}"

--- a/utils/common.sh
+++ b/utils/common.sh
@@ -1282,6 +1282,46 @@ function required_collections_present() {
     [ "$found_any" == "true" ]
 }
 
+# Whether this run may use Mitogen at all.
+#
+# Mitogen supports Ansible 10 only on Python 3.11 and newer, and the installer
+# still supports older interpreters, so the version gate is what keeps those
+# runs on Ansible's own strategy instead of an unsupported pairing. The switch
+# is checked here too, so an opted-out run does not even install the package.
+function mitogen_is_supported() {
+    [ "${OVOS_INSTALLER_MITOGEN:-true}" == "true" ] || return 1
+    [ -n "${PYTHON:-}" ] || return 1
+    [ "$(ver "$PYTHON")" -ge "$(ver 3.11)" ]
+}
+
+# Point Ansible at the Mitogen strategy, and say nothing if that is not on the
+# table. Resolving the plugin directory from the installed package is what
+# keeps this working whichever Python the virtualenv was built with.
+#
+# Falling back is deliberate: a missing or unloadable plugin costs the run its
+# speedup, and refusing to install over it would cost the user their install.
+function configure_ansible_strategy() {
+    local strategy_path=""
+
+    if ! mitogen_is_supported; then
+        printf '%s\n' "[info] Mitogen not used (python ${PYTHON:-unknown}, OVOS_INSTALLER_MITOGEN=${OVOS_INSTALLER_MITOGEN:-true})" &>>"$LOG_FILE"
+        return 0
+    fi
+
+    strategy_path="$("$VENV_PATH/bin/python3" -c \
+        'import os, ansible_mitogen.plugins.strategy as s; print(os.path.dirname(s.__file__))' \
+        2>>"$LOG_FILE" || true)"
+
+    if [ -z "$strategy_path" ] || [ ! -d "$strategy_path" ]; then
+        printf '%s\n' "[warn] Mitogen is not importable, continuing with the default Ansible strategy." &>>"$LOG_FILE"
+        return 0
+    fi
+
+    export ANSIBLE_STRATEGY_PLUGINS="$strategy_path"
+    export ANSIBLE_STRATEGY="mitogen_linear"
+    printf '%s\n' "[info] Using Mitogen strategy from ${strategy_path}" &>>"$LOG_FILE"
+}
+
 # Install Ansible into the new Python virtual environment and install the
 # collections required by the playbook. Collections are installed into a
 # repository-local path to avoid sudo/HOME collection discovery mismatches.
@@ -1308,6 +1348,12 @@ function install_ansible() {
         "docker==7.1.0"
         "requests==2.32.5"
     )
+
+    # Part of the package set rather than a separate install, so the cache
+    # check below notices when the switch or the interpreter changes.
+    if mitogen_is_supported; then
+        ansible_packages+=("mitogen==${MITOGEN_VERSION}")
+    fi
 
     if [ "${REUSE_CACHED_ARTIFACTS:-false}" == "true" ] \
         && python_packages_match_versions "$VENV_PATH/bin/python3" "${ansible_packages[@]}"; then

--- a/utils/constants.sh
+++ b/utils/constants.sh
@@ -21,6 +21,9 @@ export EXIT_SUCCESS=0
 export I2C_BUS="1"
 export INSTALLER_VENV_NAME="ovos-installer"
 export LOG_FILE=/var/log/ovos-installer.log
+# Pinned against ANSIBLE_VERSION: mitogen patches Ansible internals, so the
+# pair is upgraded together or not at all.
+export MITOGEN_VERSION="0.3.53"
 export NEWT_COLORS="
     root=white,black
     border=black,lightgray


### PR DESCRIPTION
Ansible starts a fresh Python interpreter for every task. On `connection: local` that is nearly all of the per-task cost, and on a Raspberry Pi — cores an order of magnitude slower than a desktop, and the platform this installer mostly runs on — it is a real part of the install rather than a rounding error. [Mitogen](https://mitogen.networkgenomics.com/ansible_detailed.html) keeps one interpreter alive instead.

## Measurement

I nearly argued against this on the grounds that Mitogen's documented wins are about SSH latency and many hosts, neither of which applies to a single local host. That reasoning was wrong, and measuring said so. Pinned pair (`ansible==10.7.0`, `mitogen==0.3.53`), 160 representative tasks — `command`, `stat`, `file`, `lineinfile`, `set_fact`, `copy` — on `connection: local`, three runs each:

| strategy | wall | CPU (user+sys) | per task |
|---|---|---|---|
| stock `linear` | 17.8 – 19.0 s | 18.1 s | ~113 ms |
| `mitogen_linear` | 3.5 – 4.6 s | 3.7 s | ~25 ms |

Both runs completed all 160 tasks with `failed=0`. About **4x less wall clock and 5x less CPU** on the overhead itself.

That was measured on a fast desktop, where 15 seconds is noise. The CPU column is the transferable number: a Pi's cores are roughly ten times slower and entirely CPU-bound, so the same overhead costs minutes there, across the couple of hundred tasks a real run executes. Nothing about apt, uv or image pulls changes — the win is the glue.

## Deliberately narrow

Mitogen works by patching Ansible internals, so:

- **Python 3.11+ only**, which is what Mitogen supports for Ansible 10. Older interpreters keep exactly today's behaviour, including the 3.9 path that pins Ansible 8.
- **Pinned next to `ANSIBLE_VERSION`** in `constants.sh`, with a test asserting both. The pair is upgraded together or not at all.
- **`OVOS_INSTALLER_MITOGEN=false`** opts out, and the installer opts itself out when the package will not import. A missing plugin costs the run its speedup; it must never cost the user their install.
- **Chosen after `ANSIBLE_PYTHON_INTERPRETER`**, since that is the interpreter Mitogen starts and keeps. A test pins that ordering, because getting it backwards would silently pin the wrong interpreter on Fedora/RHEL.

## The become caveat, checked rather than assumed

Mitogen bypasses Ansible's become *plugins* and emulates sudo itself. That bites on custom become plugins, unusual `become_flags`, password prompts, or methods like `machinectl`. Audit of this playbook: **60 `become_user:` uses, all default passwordless sudo, zero `become_method`, zero `become_flags`, zero `raw`, zero `async`** — squarely inside what Mitogen emulates.

Verified empirically against both strategies, running as root and dropping to the installer user:

```
stock:   root=root user=gtrellu home=/home/gtrellu owner=gtrellu
mitogen: root=root user=gtrellu home=/home/gtrellu owner=gtrellu
```

Identity, `$HOME` and resulting file ownership are identical.

## CI

The scenario matrix already exercises Mitogen everywhere, because it is the default and the runners are Python 3.12. What was missing is the fallback, so one matrix entry opts out — that keeps the non-Mitogen path a real install rather than a code path nobody runs, and makes a regression that only appears under Mitogen attributable by diffing the two.

`profile_tasks` is enabled in `ansible.cfg`, so the per-task timings in the scenario logs give the real-install delta for free.

## Testing

- 550 bats tests (8 new), shellcheck clean under CI's options.
- The new tests cover the version gate in both directions, the kill switch, an unknown interpreter, the pin, the fallback when the package will not import, the wiring when it does, and the ordering against `ANSIBLE_PYTHON_INTERPRETER`.
- Verified the installer's own `configure_ansible_strategy` against a real venv: it resolves the plugin directory and Ansible loads the strategy.

## Worth a look during review

Default-on ships this to every user on the next run, since `installer.sh` clones `main`. The argument for it: CI runs full end-to-end installs on this path, the fallback is automatic, and off-by-default on a continuously deployed repo means it never gets real-world exercise. The argument against is that subtle become or environment differences would surface in the field rather than in CI. `OVOS_INSTALLER_MITOGEN=false` is the kill switch either way, and flipping the default to opt-in is a one-line change if you would rather start there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Installer runs through Mitogen by default when supported, improving installation speed.
  - Automatically falls back to Ansible’s standard strategy when Mitogen is unavailable or unsupported.
  - Added the `OVOS_INSTALLER_MITOGEN=false` option to disable Mitogen and use Ansible’s standard strategy.

- **Documentation**
  - Added usage examples and details about Mitogen support, compatibility, fallback behavior, and installation speed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->