### PR TITLE
fix: drop the obsolete lgpl extra from ovos-core installs

### DIFF
--- a/ansible/roles/ovos_virtualenv/templates/virtualenv/core-requirements.txt.j2
+++ b/ansible/roles/ovos_virtualenv/templates/virtualenv/core-requirements.txt.j2
@@ -2,7 +2,7 @@
 {% set _ovos_is_mark2_family = _ovos_is_raspberry_pi_4 and ('tas5806' in (ovos_installer_i2c_devices | default([]))) %}
 {% set _ovos_is_devkit = _ovos_is_mark2_family and ('attiny1614' in (ovos_installer_i2c_devices | default([]))) %}
 ovos-audio[extras]
-ovos-core[lgpl,plugins]
+ovos-core[plugins]
 ovos-dinkum-listener[{{ 'extras' if ansible_facts.system == 'Darwin' else 'extras,linux' }}]
 # Keep configured VAD selection and its fallback installed explicitly.
 {% if (ovos_installer_cpu_is_capable | default(false)) | bool %}

--- a/ansible/roles/ovos_virtualenv/templates/virtualenv/server-requirements.txt.j2
+++ b/ansible/roles/ovos_virtualenv/templates/virtualenv/server-requirements.txt.j2
@@ -5,7 +5,7 @@ hivemind-http-protocol
 hivemind-presence
 
 # OVOS
-ovos-core[lgpl,plugins]
+ovos-core[plugins]
 
 # A terminal to talk to OVOS through, for when there is no microphone yet or
 # none at all: type an utterance, read the reply, watch which skill answered.


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting. PyPI metadata claims below verified against the live index.

The `lgpl` extra no longer exists on current ovos-core: the 3.2.2a1 wheel's requires_dist contains zero entries guarded by `extra == "lgpl"`, and the `plugins` extra carries `ovos_padatious<3.0.0,>=2.0.1a2` — the padatious 2.x line is pure-numpy Apache-2.0 with no fann2 dependency, which is why the extra went away. Installs tracking new cores currently request a dead extra and get an unknown-extra warning on every run.

Both templates that referenced `ovos-core[lgpl,plugins]` (core-requirements and server-requirements) now say `ovos-core[plugins]`. Backward-harmless: against older cores that still ship the extra, omitting it only skips the legacy fann2 padatious line, which the plugins extra's 2.x pin supersedes.

This repo is not under my maintenance authority — routed as a suggestion for the installer owner to review and merge.