### PR TITLE
Do not autoconfigure through a container that is not there

### DIFF
--- a/.github/workflows/scenarios-ubuntu2404.yml
+++ b/.github/workflows/scenarios-ubuntu2404.yml
@@ -47,6 +47,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Decide whether Linux jobs are needed
@@ -82,6 +83,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Restore installer caches
         uses: actions/cache@v6.1.0
@@ -221,6 +224,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Restore installer caches
         uses: actions/cache@v6.1.0
@@ -375,6 +380,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Restore installer caches
         uses: actions/cache@v6.1.0
@@ -500,6 +507,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Restore installer caches
         uses: actions/cache@v6.1.0
@@ -648,6 +657,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Install installer requirements
         run: |
@@ -711,6 +722,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Install installer requirements
         run: |

--- a/.github/workflows/scenarios-ubuntu2404.yml
+++ b/.github/workflows/scenarios-ubuntu2404.yml
@@ -632,6 +632,65 @@ jobs:
           ls -la "$HOME/.local/state/mycroft" || true
           ls -la "$HOME/.config/ovos-installer" || true
 
+  linux-satellite-scenario:
+    # Every other scenario job installs the "ovos" profile, so a satellite has
+    # only ever been syntax-checked here. That is how an exec into a container
+    # no satellite composes survived for months: nothing installed one.
+    #
+    # One job, one profile, the scenario file this repository already ships.
+    needs: changes
+    if: >-
+      needs.changes.outputs.run == 'true'
+      && (github.event_name == 'pull_request' || github.event_name == 'push')
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Install installer requirements
+        run: |
+          sudo apt-get update
+          sudo apt-get --no-install-recommends install -y bash jq expect whiptail git curl
+
+      - name: Ensure Docker is available
+        run: |
+          if command -v docker >/dev/null 2>&1; then
+            sudo systemctl start docker || true
+          fi
+
+      - name: Ensure ALSA device path is Docker-compatible
+        run: |
+          if [ ! -e /dev/snd ]; then
+            sudo mkdir -p /dev/snd
+            sudo chmod 0755 /dev/snd
+          fi
+
+          if [ -d /dev/snd ] && ! find /dev/snd -maxdepth 1 \( -type c -o -type b \) | grep -q .; then
+            sudo mknod /dev/snd/controlC0 c 1 3
+            sudo chmod 0666 /dev/snd/controlC0
+          fi
+
+      - name: Use the satellite scenario this repository ships
+        run: |
+          mkdir -p "$HOME/.config/ovos-installer"
+          cp scenarios/scenario-satellite.yml "$HOME/.config/ovos-installer/scenario.yaml"
+          cat "$HOME/.config/ovos-installer/scenario.yaml"
+
+      - name: Run the satellite install
+        # The HiveMind host in that scenario is not reachable from here, and
+        # does not need to be: this covers the installer's own satellite path,
+        # not a working connection to a hive.
+        run: sudo -E env REUSE_CACHED_ARTIFACTS=true bash setup.sh
+
+      - name: Dump diagnostics on failure
+        if: failure()
+        run: |
+          sudo docker ps -a || true
+          sudo tail -n 200 /var/log/ovos-installer.log || true
+          sudo tail -n 200 /var/log/ovos-ansible.log || true
+
   linux-negative-scenarios:
     needs: changes
     if: >-

--- a/ansible/roles/ovos_containers/tasks/composer.yml
+++ b/ansible/roles/ovos_containers/tasks/composer.yml
@@ -71,6 +71,11 @@
   when:
     - not ansible_check_mode
     - ovos_installer_ovos_config_autoconfigure_enabled | default(false) | bool
+    # ovos_cli is defined by the base, Windows and Raspberry Pi compositions,
+    # and every one of those is gated on a desktop profile. A satellite has
+    # none of them, so without this the install dies here on "Could not find
+    # container ovos_cli" after the stack is already up.
+    - ovos_containers_is_desktop_profile | bool
 
 - name: Compute optional skills flags
   vars:

--- a/tests/bats/code_quality.bats
+++ b/tests/bats/code_quality.bats
@@ -2243,11 +2243,41 @@ YAML
     "
     assert_success
 
-    # The compose files that define ovos_cli carry the same gate, so the two
-    # cannot drift apart without this failing.
-    run grep -c 'ovos_containers_is_desktop_profile | bool and' \
+    # The three compositions that define ovos_cli - base, Windows and
+    # Raspberry Pi - each carry the same gate. Assert the count, so removing
+    # one is caught rather than hidden by the other two still matching.
+    run command grep -c 'ovos_containers_is_desktop_profile | bool and' \
         ansible/roles/ovos_containers/defaults/main.yml
     assert_success
+    assert_output "3"
+}
+
+@test "container_exec_tasks_are_all_restricted_to_a_profile_that_has_them" {
+    # The general form of the bug above: a task that execs into a container
+    # runs on every profile unless it says otherwise, and the compositions
+    # that define those containers are per-profile. An unguarded exec is a
+    # late, confusing failure - the stack is already up and pulled by then.
+    #
+    # Every docker_container_exec must name a profile in its `when:`.
+    local file="ansible/roles/ovos_containers/tasks/composer.yml"
+    local total guarded
+
+    total="$(command grep -c 'community.docker.docker_container_exec' "$file")"
+    [ "$total" -ge 1 ] || { echo "no container exec tasks found - did the file move?" >&2; return 1; }
+
+    # Count the exec tasks whose following `when:` block names a profile.
+    guarded="$(awk '
+        /community\.docker\.docker_container_exec/ { in_task = 1; seen = 0 }
+        in_task && /ovos_containers_is_desktop_profile|ovos_installer_profile ==|ovos_containers_profile ==/ { seen = 1 }
+        in_task && /^- name:/ && NR > 1 { if (seen) count++; in_task = 0 }
+        END { if (in_task && seen) count++; print count + 0 }
+    ' "$file")"
+
+    if [ "$guarded" -ne "$total" ]; then
+        echo "container exec tasks: $total, profile-guarded: $guarded" >&2
+        echo "an exec into a per-profile container needs a profile in its when:" >&2
+        return 1
+    fi
 }
 
 @test "virtualenv_installs_the_terminal_client_where_it_can_read_the_config" {

--- a/tests/bats/code_quality.bats
+++ b/tests/bats/code_quality.bats
@@ -2230,6 +2230,26 @@ YAML
     assert_success
 }
 
+@test "container_autoconfigure_only_runs_where_ovos_cli_exists" {
+    # ovos_cli comes from the base, Windows and Raspberry Pi compositions, and
+    # all three are gated on a desktop profile. A satellite container install
+    # has none of them, so an unguarded exec kills the run with "Could not find
+    # container ovos_cli" after the stack is already up.
+    local file="ansible/roles/ovos_containers/tasks/composer.yml"
+
+    run bash -c "
+        awk '/^- name: Merge ovos-config language recommendations/,/^\$/' '$file' \
+          | grep -q 'ovos_containers_is_desktop_profile'
+    "
+    assert_success
+
+    # The compose files that define ovos_cli carry the same gate, so the two
+    # cannot drift apart without this failing.
+    run grep -c 'ovos_containers_is_desktop_profile | bool and' \
+        ansible/roles/ovos_containers/defaults/main.yml
+    assert_success
+}
+
 @test "virtualenv_installs_the_terminal_client_where_it_can_read_the_config" {
     # The client is designed to share the OVOS virtualenv: that is how it finds
     # the configuration and the logs. It goes in the profiles that run OVOS

--- a/tests/bats/code_quality.bats
+++ b/tests/bats/code_quality.bats
@@ -2258,24 +2258,53 @@ YAML
     # that define those containers are per-profile. An unguarded exec is a
     # late, confusing failure - the stack is already up and pulled by then.
     #
-    # Every docker_container_exec must name a profile in its `when:`.
-    local file="ansible/roles/ovos_containers/tasks/composer.yml"
-    local total guarded
+    # Every docker_container_exec must name a profile in its own `when:`.
+    # Only the `when:` field counts: a profile named in the task title, in
+    # the command, or in a nearby comment guards nothing at runtime, so it
+    # must not satisfy this check either.
+    local report total guarded offenders
+    report="$(command find ansible -name '*.yml' -print0 | command xargs -0 awk '
+        function endtask() {
+            if (has_exec) {
+                total++
+                if (guarded) ok++; else offenders = offenders "    " where "\n"
+            }
+            has_exec = 0; guarded = 0; in_when = 0
+        }
+        /^[[:space:]]*-[[:space:]]+name:/ {
+            endtask()
+            where = FILENAME ":" FNR
+        }
+        {
+            probe = $0
+            sub(/#.*/, "", probe)                 # a comment guards nothing
+            if (probe ~ /^[[:space:]]*$/) next
+            indent = match(probe, /[^[:space:]]/) - 1
+            if (in_when && indent <= when_indent) in_when = 0
+            if (probe ~ /community\.docker\.docker_container_exec/) has_exec = 1
+            if (probe ~ /^[[:space:]]*when:/) {
+                in_when = 1
+                when_indent = indent
+                sub(/^[[:space:]]*when:[[:space:]]*/, "", probe)   # inline form
+            }
+            if (!in_when) next
+            if (probe ~ /ovos_containers_is_desktop_profile/ ||
+                probe ~ /ovos_installer_profile[[:space:]]*==/ ||
+                probe ~ /ovos_containers_profile[[:space:]]*==/) guarded = 1
+        }
+        END { endtask(); printf "%d %d\n%s", total + 0, ok + 0, offenders }
+    ')"
 
-    total="$(command grep -c 'community.docker.docker_container_exec' "$file")"
-    [ "$total" -ge 1 ] || { echo "no container exec tasks found - did the file move?" >&2; return 1; }
+    total="$(printf '%s' "$report" | head -1 | cut -d" " -f1)"
+    guarded="$(printf '%s' "$report" | head -1 | cut -d" " -f2)"
+    offenders="$(printf '%s' "$report" | tail -n +2)"
 
-    # Count the exec tasks whose following `when:` block names a profile.
-    guarded="$(awk '
-        /community\.docker\.docker_container_exec/ { in_task = 1; seen = 0 }
-        in_task && /ovos_containers_is_desktop_profile|ovos_installer_profile ==|ovos_containers_profile ==/ { seen = 1 }
-        in_task && /^- name:/ && NR > 1 { if (seen) count++; in_task = 0 }
-        END { if (in_task && seen) count++; print count + 0 }
-    ' "$file")"
+    [ "$total" -ge 1 ] || { echo "no container exec tasks found - did the module move?" >&2; return 1; }
 
     if [ "$guarded" -ne "$total" ]; then
         echo "container exec tasks: $total, profile-guarded: $guarded" >&2
-        echo "an exec into a per-profile container needs a profile in its when:" >&2
+        echo "an exec into a per-profile container needs a profile in its when::" >&2
+        echo "$offenders" >&2
         return 1
     fi
 }


### PR DESCRIPTION
A satellite container install dies partway through:

```
TASK [ovos_containers : Merge ovos-config language recommendations into mounted config]
fatal: [127.0.0.1]: FAILED! =>
    changed: false
    msg: Could not find container "ovos_cli"
task path: .../ansible/roles/ovos_containers/tasks/composer.yml:63
```

## Why

The task execs `ovos-config autoconfigure` inside `ovos_cli`. That container is defined by the base, Windows and Raspberry Pi compositions — and all three are gated on `ovos_containers_is_desktop_profile`, which is `ovos` or `listener`. A satellite composes none of them, so there is nothing to exec into.

`ovos_installer_ovos_config_autoconfigure_enabled` already skips the `server` profile, and that is what hid the real shape of the requirement. It is not *"any profile except server"* — it is *"profiles whose composition defines `ovos_cli`"*. Server was simply the case someone hit first.

The task now carries that condition directly, which is the same gate the compose definitions use, so the two cannot drift apart silently.

## Why it is worth a fix rather than a note

It fails late. By the time the run aborts, the images are pulled and the stack is up; the user watches a long install collapse at the very end over a language preference that a satellite has no local config to apply anyway.

## Checked

- Ruled out the recent `ovos-cli` image change first, rather than assuming: pulled `smartgic/ovos-cli:alpha`, confirmed it is built from the current revision, starts, and has both `ovos-config` and `ovos-tui` on the container's `PATH`. The image is healthy — the container simply is not composed for this profile.
- 552 bats tests pass; `ansible-lint` clean on the changed file under the `production` profile; shellcheck clean.
- The new test was verified by deleting the guard and watching it fail, then restoring it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented configuration commands from running on non-desktop profiles where the required container is unavailable.
  * Eliminated startup failures caused by attempts to access the missing container on satellite installations.

* **Tests**
  * Added coverage to verify that container-specific configuration runs only when the container exists.
  * Added checks ensuring container execution tasks are restricted to profiles where they are supported.

* **CI**
  * Added automated satellite scenario coverage on Ubuntu 24.04, including failure diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->