### PR TITLE
fix: install the fann2 build chain only where padatious still needs it

### DIFF
--- a/.github/scripts/assert_intent_engine.sh
+++ b/.github/scripts/assert_intent_engine.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Assert the virtualenv ended up with a padatious intent engine, and that the
+# fann2 build chain matches the padatious it actually got.
+#
+# padatious reaches the venv only through an ovos-core extra - no requirements
+# template asks for it by name - and which extra carries it changed between the
+# 1.x and 2.x lines. That makes it quietly droppable: an install can succeed,
+# report failed=0, and have no intent engine at all. This is the check that
+# says so out loud.
+#
+# The fann2 half is derived from the installed padatious rather than from the
+# channel, so it keeps holding once stable and testing move to a 2.x core.
+
+set -euo pipefail
+
+python_bin="${1:?usage: assert_intent_engine.sh <venv-python> [run-as-user]}"
+run_as="${2:-}"
+
+assertion=$(
+    cat <<'PY'
+from importlib.metadata import PackageNotFoundError, version
+
+
+def installed(name):
+    try:
+        return version(name)
+    except PackageNotFoundError:
+        return None
+
+
+padatious = installed("ovos-padatious")
+if padatious is None:
+    raise SystemExit(
+        "no intent engine: ovos-padatious is not installed. It reaches the venv "
+        "only through an ovos-core extra, so an extra was changed without an "
+        "explicit replacement requirement."
+    )
+
+fann2 = installed("fann2")
+needs_fann2 = int(padatious.split(".")[0]) < 2
+
+if needs_fann2 and fann2 is None:
+    raise SystemExit(
+        f"ovos-padatious {padatious} is a 1.x release and needs fann2, "
+        "but fann2 is not installed - the build chain was skipped where it "
+        "was still required."
+    )
+
+if not needs_fann2 and fann2 is not None:
+    # Not fatal: a reused venv can still carry it from an earlier install.
+    print(
+        f"note: ovos-padatious {padatious} does not need fann2, "
+        f"yet fann2 {fann2} is present"
+    )
+
+print(f"intent engine ok: ovos-padatious {padatious}, fann2 {fann2 or 'not needed'}")
+PY
+)
+
+if [ ! -x "${python_bin}" ]; then
+    echo "no virtualenv python at ${python_bin}" >&2
+    exit 1
+fi
+
+if [ -n "${run_as}" ]; then
+    sudo -u "${run_as}" "${python_bin}" -c "${assertion}"
+else
+    "${python_bin}" -c "${assertion}"
+fi

--- a/.github/workflows/macos_ci.yml
+++ b/.github/workflows/macos_ci.yml
@@ -278,6 +278,9 @@ jobs:
             exit 1
           fi
 
+      - name: Validate the intent engine survived the install
+        run: .github/scripts/assert_intent_engine.sh "$HOME/.venvs/ovos/bin/python"
+
       - name: Create uninstall scenario
         shell: bash
         run: |

--- a/.github/workflows/scenarios-archlinux.yml
+++ b/.github/workflows/scenarios-archlinux.yml
@@ -101,6 +101,12 @@ jobs:
           print("fann2 usable, num_input =", network.get_num_input())
           PY
 
+      - name: Validate the intent engine survived the install
+        run: |
+          .github/scripts/assert_intent_engine.sh \
+            "${OVOS_CI_INSTALL_HOME}/.venvs/ovos/bin/python" \
+            "$OVOS_CI_INSTALL_USER"
+
       - name: Run ovos_virtualenv uninstall
         run: .github/scripts/run_virtualenv_role.sh true
 

--- a/.github/workflows/scenarios-ubuntu2404.yml
+++ b/.github/workflows/scenarios-ubuntu2404.yml
@@ -159,6 +159,10 @@ jobs:
             exit 1
           fi
 
+      - name: Validate the intent engine survived the install
+        if: matrix.method == 'virtualenv'
+        run: .github/scripts/assert_intent_engine.sh "$HOME/.venvs/ovos/bin/python"
+
       - name: Create uninstall scenario file
         shell: bash
         run: |
@@ -324,6 +328,10 @@ jobs:
             echo "Installer runtime ${elapsed}s exceeded threshold ${OVOS_CI_MAX_INSTALL_SECONDS}s"
             exit 1
           fi
+
+      - name: Validate the intent engine survived the install
+        if: matrix.method == 'virtualenv'
+        run: .github/scripts/assert_intent_engine.sh "$HOME/.venvs/ovos/bin/python"
 
       - name: Create uninstall scenario file
         shell: bash

--- a/ansible/roles/ovos_virtualenv/defaults/main.yml
+++ b/ansible/roles/ovos_virtualenv/defaults/main.yml
@@ -42,6 +42,10 @@ ovos_virtualenv_uv_environment: >-
         else {}
       )
   }}
+# Overridden in constraints.yml from the channel pin; defaults to the old
+# behaviour (build fann2) so a skipped or unreadable constraints file never
+# silently drops the intent engine.
+ovos_virtualenv_needs_fann2: true
 ovos_virtualenv_constraints_url: "https://raw.githubusercontent.com/OpenVoiceOS/ovos-releases/refs/heads/main/constraints-{{ ovos_installer_channel }}.txt"
 ovos_virtualenv_constraints_path: "{{ ovos_virtualenv_tmp_dir }}/constraints-{{ ovos_installer_channel }}.txt"
 ovos_virtualenv_constraints_refresh_interval: "{{ ovos_installer_constraints_refresh_interval | default(21600) }}"
@@ -116,10 +120,8 @@ ovos_virtualenv_macos_fann_library_path: >-
   {{ ovos_virtualenv_macos_fann_source_lib_dir }}{{ ':' ~ ovos_virtualenv_macos_fann_target_lib_dir if ovos_virtualenv_macos_fann_source_lib_dir != ovos_virtualenv_macos_fann_target_lib_dir else '' }}
 ovos_virtualenv_macos_fann_pkg_config_path: >-
   {{ ovos_virtualenv_macos_fann_source_lib_dir }}/pkgconfig{{ ':' ~ ovos_virtualenv_macos_fann_target_lib_dir ~ '/pkgconfig' if ovos_virtualenv_macos_fann_source_lib_dir != ovos_virtualenv_macos_fann_target_lib_dir else '' }}
-ovos_virtualenv_packages_debian:
+ovos_virtualenv_packages_debian_base:
   - build-essential
-  - swig
-  - libfann-dev
   - libasound2-dev
   - libpulse-dev
   - libportaudio2
@@ -137,10 +139,8 @@ ovos_virtualenv_packages_debian:
   - libicu-dev
   - portaudio19-dev
   - libjpeg-dev
-ovos_virtualenv_packages_redhat:
+ovos_virtualenv_packages_redhat_base:
   - gcc-c++
-  - swig
-  - fann-devel
   - alsa-lib-devel
   - pulseaudio-libs-devel
   - portaudio
@@ -153,10 +153,8 @@ ovos_virtualenv_packages_redhat:
   - libicu-devel
   - portaudio-devel
   - espeak-ng
-ovos_virtualenv_packages_suse:
+ovos_virtualenv_packages_suse_base:
   - gcc-c++
-  - swig
-  - libfann-devel
   - alsa-lib-devel
   - libpulse-devel
   - libportaudio2
@@ -168,9 +166,8 @@ ovos_virtualenv_packages_suse:
   - mpv
   - libopenblas_serial-devel
   - portaudio-devel
-ovos_virtualenv_packages_arch:
+ovos_virtualenv_packages_arch_base:
   - base-devel
-  - swig
   - alsa-lib
   - portaudio
   - mpg123
@@ -180,12 +177,8 @@ ovos_virtualenv_packages_arch:
   - libxslt
   - openblas
   - espeak-ng
-ovos_virtualenv_packages_arch_aur:
-  - fann
 ovos_virtualenv_packages_arch_tracked: "{{ (ovos_virtualenv_packages_arch + ovos_virtualenv_packages_arch_aur) | unique }}"
-ovos_virtualenv_macos_packages:
-  - fann
-  - swig
+ovos_virtualenv_macos_packages_base:
   - pkg-config
   - portaudio
   - mpg123
@@ -198,6 +191,34 @@ ovos_virtualenv_macos_packages:
   - jpeg-turbo
   - espeak-ng
   - brightness
+
+# ovos-padatious 1.x builds the fann2 C extension from source, which needs swig
+# and the FANN headers. padatious 2.x dropped fann2 entirely, so a channel on it
+# installs none of this and skips the swig2.0 shim in packages.yml. Composed
+# lazily: ovos_virtualenv_needs_fann2 is decided in constraints.yml, before the
+# package tasks run.
+ovos_virtualenv_fann2_packages_debian:
+  - swig
+  - libfann-dev
+ovos_virtualenv_fann2_packages_redhat:
+  - swig
+  - fann-devel
+ovos_virtualenv_fann2_packages_suse:
+  - swig
+  - libfann-devel
+ovos_virtualenv_fann2_packages_arch:
+  - swig
+ovos_virtualenv_fann2_packages_arch_aur:
+  - fann
+ovos_virtualenv_fann2_packages_macos:
+  - fann
+  - swig
+ovos_virtualenv_packages_debian: "{{ ovos_virtualenv_packages_debian_base + (ovos_virtualenv_fann2_packages_debian if ovos_virtualenv_needs_fann2 | bool else []) }}"
+ovos_virtualenv_packages_redhat: "{{ ovos_virtualenv_packages_redhat_base + (ovos_virtualenv_fann2_packages_redhat if ovos_virtualenv_needs_fann2 | bool else []) }}"
+ovos_virtualenv_packages_suse: "{{ ovos_virtualenv_packages_suse_base + (ovos_virtualenv_fann2_packages_suse if ovos_virtualenv_needs_fann2 | bool else []) }}"
+ovos_virtualenv_packages_arch: "{{ ovos_virtualenv_packages_arch_base + (ovos_virtualenv_fann2_packages_arch if ovos_virtualenv_needs_fann2 | bool else []) }}"
+ovos_virtualenv_macos_packages: "{{ ovos_virtualenv_macos_packages_base + (ovos_virtualenv_fann2_packages_macos if ovos_virtualenv_needs_fann2 | bool else []) }}"
+ovos_virtualenv_packages_arch_aur: "{{ ovos_virtualenv_fann2_packages_arch_aur if ovos_virtualenv_needs_fann2 | bool else [] }}"
 ovos_virtualenv_gui_packages_debian:
   - cmake
   - gettext

--- a/ansible/roles/ovos_virtualenv/tasks/constraints.yml
+++ b/ansible/roles/ovos_virtualenv/tasks/constraints.yml
@@ -1,0 +1,63 @@
+---
+# The constraints file is fetched here rather than in venv.yml because the
+# package tasks need it too: whether this channel still builds fann2 is decided
+# from its ovos-padatious pin, and that decision has to be made before any
+# system package is installed.
+- name: Check cached OVOS constraints file
+  ansible.builtin.stat:
+    path: "{{ ovos_virtualenv_constraints_path }}"
+  register: ovos_virtualenv_constraints_file
+  changed_when: false
+
+- name: Decide whether OVOS constraints refresh is required
+  ansible.builtin.set_fact:
+    ovos_virtualenv_constraints_refresh_required: >-
+      {{
+        ovos_virtualenv_constraints_force_sync | bool
+        or not (ovos_virtualenv_constraints_file.stat.exists | default(false))
+        or (
+          (lookup('pipe', 'date +%s') | int)
+          - (ovos_virtualenv_constraints_file.stat.mtime | default(0) | int)
+          > (ovos_virtualenv_constraints_refresh_interval | int)
+        )
+      }}
+  changed_when: false
+
+- name: Cache OVOS constraints file
+  ansible.builtin.get_url:
+    url: "{{ ovos_virtualenv_constraints_url }}"
+    dest: "{{ ovos_virtualenv_constraints_path }}"
+    owner: "{{ ovos_installer_user }}"
+    group: "{{ ovos_installer_group }}"
+    mode: "0644"
+  when: ovos_virtualenv_constraints_refresh_required | bool
+
+# Read back rather than trust the download: in check mode get_url writes
+# nothing, and a cached file from a previous run is just as authoritative.
+- name: Read OVOS constraints for the fann2 build decision
+  ansible.builtin.slurp:
+    src: "{{ ovos_virtualenv_constraints_path }}"
+  register: ovos_virtualenv_constraints_blob
+  failed_when: false
+  changed_when: false
+
+# fann2 is a dependency of ovos-padatious 1.x only; 2.x dropped it. Keying on
+# the resolved pin rather than the channel name means this flips on its own when
+# stable and testing move to a padatious 2.x core, instead of needing an edit.
+# An unreadable or pinless file falls back to 1, i.e. the previous behaviour.
+- name: Derive whether this channel still needs the fann2 build chain
+  vars:
+    _ovos_constraints_text: "{{ ovos_virtualenv_constraints_blob.content | default('') | b64decode }}"
+    _ovos_padatious_major: >-
+      {{
+        (
+          _ovos_constraints_text
+          | regex_search('ovos[-_]padatious[^0-9\n]*([0-9]+)', '\1')
+          | default([], true)
+          | first
+          | default('1')
+        )
+      }}
+  ansible.builtin.set_fact:
+    ovos_virtualenv_needs_fann2: "{{ (_ovos_padatious_major | int) < 2 }}"
+  changed_when: false

--- a/ansible/roles/ovos_virtualenv/tasks/main.yml
+++ b/ansible/roles/ovos_virtualenv/tasks/main.yml
@@ -4,6 +4,10 @@
   tags:
     - always
 
+- name: Include constraints.yml
+  ansible.builtin.import_tasks: constraints.yml
+  when: not (ovos_virtualenv_is_cleaning | bool)
+
 - name: Include packages.yml
   ansible.builtin.import_tasks: packages.yml
   when: not (ovos_virtualenv_is_cleaning | bool)

--- a/ansible/roles/ovos_virtualenv/tasks/packages.yml
+++ b/ansible/roles/ovos_virtualenv/tasks/packages.yml
@@ -159,6 +159,7 @@
     - ansible_facts.system == "Darwin"
     - ovos_virtualenv_macos_fann_source_lib_dir != ovos_virtualenv_macos_fann_target_lib_dir
 
+    - ovos_virtualenv_needs_fann2 | bool
 - name: Discover Homebrew fann dylibs on macOS
   ansible.builtin.find:
     paths: "{{ ovos_virtualenv_macos_fann_source_lib_dir }}"
@@ -170,6 +171,7 @@
     - ovos_virtualenv_macos_fann_source_lib_dir != ovos_virtualenv_macos_fann_target_lib_dir
     - ovos_virtualenv_macos_fann_source_dir.stat.exists | default(false)
 
+    - ovos_virtualenv_needs_fann2 | bool
 - name: Ensure fallback lib directory exists for fann build compatibility
   ansible.builtin.file:
     path: "{{ ovos_virtualenv_macos_fann_target_lib_dir }}"
@@ -180,6 +182,7 @@
     - ovos_virtualenv_macos_fann_source_lib_dir != ovos_virtualenv_macos_fann_target_lib_dir
     - ovos_virtualenv_macos_fann_dylibs.matched | default(0) | int > 0
 
+    - ovos_virtualenv_needs_fann2 | bool
 - name: Create fann compatibility symlinks for legacy build scripts
   ansible.builtin.file:
     src: "{{ item.path }}"
@@ -194,13 +197,16 @@
     - ovos_virtualenv_macos_fann_source_lib_dir != ovos_virtualenv_macos_fann_target_lib_dir
     - ovos_virtualenv_macos_fann_dylibs.matched | default(0) | int > 0
 
+    - ovos_virtualenv_needs_fann2 | bool
 - name: Handle fann package from AUR (Arch based only)
   become_user: "{{ ovos_installer_user }}"
   kewlfft.aur.aur:
     name: "{{ ovos_virtualenv_packages_arch_aur | default([]) }}"
     use: makepkg
   register: ovos_virtualenv_aur_package_install_result
-  when: ansible_facts.os_family == "Archlinux"
+  when:
+    - ansible_facts.os_family == "Archlinux"
+    - ovos_virtualenv_needs_fann2 | bool
   tags:
     - skip_ansible_lint
 
@@ -222,7 +228,9 @@
     owner: "{{ ovos_installer_user }}"
     group: "{{ ovos_installer_group }}"
     mode: "0755"
-  when: ansible_facts.system in ['Linux', 'Darwin']
+  when:
+    - ansible_facts.system in ['Linux', 'Darwin']
+    - ovos_virtualenv_needs_fann2 | bool
 
 # "command -v" is a shell builtin, unlike which(1), which is a separate package
 # that minimal images do not always carry. Resolving through it means a missing
@@ -240,7 +248,9 @@
   failed_when: false
   environment:
     PATH: "{{ ovos_virtualenv_homebrew_path }}:{{ ansible_env.PATH | default('/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin') }}"
-  when: ansible_facts.system in ['Linux', 'Darwin']
+  when:
+    - ansible_facts.system in ['Linux', 'Darwin']
+    - ovos_virtualenv_needs_fann2 | bool
 
 # swig 4.5.0 dropped the Python 2 compatibility macros from its generated
 # wrappers, which fann2 1.0.7 typemaps still call. The shim runs the real swig
@@ -256,3 +266,4 @@
   when:
     - ansible_facts.system in ['Linux', 'Darwin']
     - (ovos_virtualenv_swig_bin.stdout | default('') | trim | length) > 0
+    - ovos_virtualenv_needs_fann2 | bool

--- a/ansible/roles/ovos_virtualenv/tasks/venv.yml
+++ b/ansible/roles/ovos_virtualenv/tasks/venv.yml
@@ -215,39 +215,6 @@
     - not (ovos_virtualenv_is_cleaning | bool)
     - ovos_installer_enable_ggwave | bool
 
-- name: Check cached OVOS constraints file
-  ansible.builtin.stat:
-    path: "{{ ovos_virtualenv_constraints_path }}"
-  register: ovos_virtualenv_constraints_file
-  changed_when: false
-  when: not (ovos_virtualenv_is_cleaning | bool)
-
-- name: Decide whether OVOS constraints refresh is required
-  ansible.builtin.set_fact:
-    ovos_virtualenv_constraints_refresh_required: >-
-      {{
-        ovos_virtualenv_constraints_force_sync | bool
-        or not (ovos_virtualenv_constraints_file.stat.exists | default(false))
-        or (
-          (lookup('pipe', 'date +%s') | int)
-          - (ovos_virtualenv_constraints_file.stat.mtime | default(0) | int)
-          > (ovos_virtualenv_constraints_refresh_interval | int)
-        )
-      }}
-  changed_when: false
-  when: not (ovos_virtualenv_is_cleaning | bool)
-
-- name: Cache OVOS constraints file
-  ansible.builtin.get_url:
-    url: "{{ ovos_virtualenv_constraints_url }}"
-    dest: "{{ ovos_virtualenv_constraints_path }}"
-    owner: "{{ ovos_installer_user }}"
-    group: "{{ ovos_installer_group }}"
-    mode: "0644"
-  when:
-    - not (ovos_virtualenv_is_cleaning | bool)
-    - ovos_virtualenv_constraints_refresh_required | bool
-
 - name: Install Open Voice OS in Python venv
   become: true
   become_user: "{{ ovos_installer_user }}"

--- a/ansible/roles/ovos_virtualenv/templates/virtualenv/core-requirements.txt.j2
+++ b/ansible/roles/ovos_virtualenv/templates/virtualenv/core-requirements.txt.j2
@@ -2,7 +2,10 @@
 {% set _ovos_is_mark2_family = _ovos_is_raspberry_pi_4 and ('tas5806' in (ovos_installer_i2c_devices | default([]))) %}
 {% set _ovos_is_devkit = _ovos_is_mark2_family and ('attiny1614' in (ovos_installer_i2c_devices | default([]))) %}
 ovos-audio[extras]
-ovos-core[lgpl,plugins]
+{# padatious 1.x lives behind the lgpl extra; 2.x moved it into plugins and
+   dropped fann2, and asking for lgpl there only earns an unknown-extra
+   warning. Same switch as the fann2 build chain in packages.yml. #}
+ovos-core[{{ 'lgpl,plugins' if ovos_virtualenv_needs_fann2 | bool else 'plugins' }}]
 ovos-dinkum-listener[{{ 'extras' if ansible_facts.system == 'Darwin' else 'extras,linux' }}]
 # Keep configured VAD selection and its fallback installed explicitly.
 {% if (ovos_installer_cpu_is_capable | default(false)) | bool %}

--- a/ansible/roles/ovos_virtualenv/templates/virtualenv/server-requirements.txt.j2
+++ b/ansible/roles/ovos_virtualenv/templates/virtualenv/server-requirements.txt.j2
@@ -5,7 +5,10 @@ hivemind-http-protocol
 hivemind-presence
 
 # OVOS
-ovos-core[lgpl,plugins]
+{# padatious 1.x lives behind the lgpl extra; 2.x moved it into plugins and
+   dropped fann2, and asking for lgpl there only earns an unknown-extra
+   warning. Same switch as the fann2 build chain in packages.yml. #}
+ovos-core[{{ 'lgpl,plugins' if ovos_virtualenv_needs_fann2 | bool else 'plugins' }}]
 
 # A terminal to talk to OVOS through, for when there is no microphone yet or
 # none at all: type an utterance, read the reply, watch which skill answered.

--- a/tests/bats/code_quality.bats
+++ b/tests/bats/code_quality.bats
@@ -606,6 +606,9 @@ function setup() {
 @test "virtualenv_caches_constraints_file_and_uses_local_constraints_for_uv" {
     local defaults_file="ansible/roles/ovos_virtualenv/defaults/main.yml"
     local tasks_file="ansible/roles/ovos_virtualenv/tasks/venv.yml"
+    # The fetch itself moved to constraints.yml so the package tasks can read
+    # the channel pin before installing anything; venv.yml still consumes it.
+    local constraints_file="ansible/roles/ovos_virtualenv/tasks/constraints.yml"
 
     run grep -q "ovos_virtualenv_constraints_url" "$defaults_file"
     assert_success
@@ -625,10 +628,10 @@ function setup() {
     run grep -q "ovos_virtualenv_uv_install_delay" "$defaults_file"
     assert_success
 
-    run grep -q "Check cached OVOS constraints file" "$tasks_file"
+    run grep -q "Check cached OVOS constraints file" "$constraints_file"
     assert_success
 
-    run grep -q "Cache OVOS constraints file" "$tasks_file"
+    run grep -q "Cache OVOS constraints file" "$constraints_file"
     assert_success
 
     run bash -c "grep -A6 -F -- \"- name: Install Open Voice OS in Python venv\" \"$tasks_file\" | grep -F -q -- \"--constraint {{ ovos_virtualenv_constraints_path }}\""
@@ -3437,4 +3440,138 @@ function teardown() {
         rm -f "utils/detect_sound.py"
     fi
     unset RUN_AS RUN_AS_UID SUDO_USER SUDO_UID USER_ID SOUND_SERVER
+}
+
+@test "virtualenv_fann2_build_chain_is_gated_on_the_channel_needing_it" {
+    # fann2 is a dependency of ovos-padatious 1.x only. A channel on 2.x must
+    # not install swig or the FANN headers, nor build the swig2.0 shim, so
+    # every fann/swig task has to carry the guard in its own `when:` - the
+    # same when-scoped check used for the container exec tasks, because a
+    # variable named in a task title or a comment gates nothing at runtime.
+    local file="ansible/roles/ovos_virtualenv/tasks/packages.yml"
+    local report named guarded offenders
+
+    report="$(awk '
+        function endtask() {
+            if (is_fann) {
+                named++
+                if (guarded) ok++; else offenders = offenders "    " where "\n"
+            }
+            is_fann = 0; guarded = 0; in_when = 0
+        }
+        /^-[[:space:]]+name:/ {
+            endtask()
+            where = FNR ": " substr($0, 9)
+            if (tolower($0) ~ /fann|swig/) is_fann = 1
+        }
+        {
+            probe = $0
+            sub(/#.*/, "", probe)
+            if (probe ~ /^[[:space:]]*$/) next
+            indent = match(probe, /[^[:space:]]/) - 1
+            if (in_when && indent <= when_indent) in_when = 0
+            if (probe ~ /^[[:space:]]*when:/) {
+                in_when = 1
+                when_indent = indent
+                sub(/^[[:space:]]*when:[[:space:]]*/, "", probe)
+            }
+            if (in_when && probe ~ /ovos_virtualenv_needs_fann2/) guarded = 1
+        }
+        END { endtask(); printf "%d %d\n%s", named + 0, ok + 0, offenders }
+    ' "$file")"
+
+    named="$(printf '%s' "$report" | head -1 | cut -d" " -f1)"
+    guarded="$(printf '%s' "$report" | head -1 | cut -d" " -f2)"
+    offenders="$(printf '%s' "$report" | tail -n +2)"
+
+    [ "$named" -ge 5 ] || { echo "expected the fann2 build tasks, found $named" >&2; return 1; }
+
+    if [ "$guarded" -ne "$named" ]; then
+        echo "fann/swig tasks: $named, guarded by ovos_virtualenv_needs_fann2: $guarded" >&2
+        echo "these run on channels that do not build fann2:" >&2
+        echo "$offenders" >&2
+        return 1
+    fi
+}
+
+@test "virtualenv_base_package_lists_carry_no_fann2_build_dependencies" {
+    # The build chain lives in its own lists so the composed ones can drop it.
+    # A stray swig back in a base list would reinstate it on every channel.
+    local defaults="ansible/roles/ovos_virtualenv/defaults/main.yml"
+
+    run awk '
+        /^ovos_virtualenv_(packages|macos_packages)[a-z_]*_base:/ { in_list = 1; name = $1; next }
+        /^[a-z]/ { in_list = 0 }
+        in_list && /^  - / && (tolower($2) ~ /^(swig|fann)/ || tolower($2) ~ /fann/) { print name " " $2 }
+    ' "$defaults"
+    assert_success
+    assert_output ""
+
+    # ...and each family still has one, so the split cannot silently vanish.
+    local family
+    for family in debian redhat suse arch macos; do
+        run grep -q "^ovos_virtualenv_fann2_packages_${family}:" "$defaults"
+        assert_success
+    done
+}
+
+@test "virtualenv_lgpl_extra_follows_the_fann2_decision" {
+    # padatious 1.x is reachable only through the lgpl extra, so dropping it
+    # unconditionally removes the intent engine from stable and testing; asking
+    # for it on a 3.x core only earns an unknown-extra warning. Neither
+    # template may hardcode the answer.
+    local template
+    for template in core server; do
+        local path="ansible/roles/ovos_virtualenv/templates/virtualenv/${template}-requirements.txt.j2"
+        run test -f "$path"
+        assert_success
+
+        run grep -q "^ovos-core\[lgpl,plugins\]" "$path"
+        assert_failure
+
+        run grep -q "ovos_virtualenv_needs_fann2" "$path"
+        assert_success
+    done
+}
+
+@test "virtualenv_constraints_are_resolved_before_the_package_tasks" {
+    # The fann2 decision is read out of the channel constraints, so the fetch
+    # has to happen before any package is installed - not in venv.yml, which
+    # runs after packages.yml.
+    local main="ansible/roles/ovos_virtualenv/tasks/main.yml"
+
+    run test -f "ansible/roles/ovos_virtualenv/tasks/constraints.yml"
+    assert_success
+
+    local constraints_line packages_line
+    constraints_line="$(command grep -n "import_tasks: constraints.yml" "$main" | cut -d: -f1)"
+    packages_line="$(command grep -n "import_tasks: packages.yml" "$main" | cut -d: -f1)"
+
+    [ -n "$constraints_line" ] || { echo "constraints.yml is never imported" >&2; return 1; }
+    [ "$constraints_line" -lt "$packages_line" ] || {
+        echo "constraints.yml ($constraints_line) must be imported before packages.yml ($packages_line)" >&2
+        return 1
+    }
+
+    # venv.yml must not fetch them a second time.
+    run grep -q "Cache OVOS constraints file" "ansible/roles/ovos_virtualenv/tasks/venv.yml"
+    assert_failure
+}
+
+@test "virtualenv_fann2_decision_fails_safe_towards_building_it" {
+    # An unreadable or missing constraints file must keep the previous
+    # behaviour. Dropping the intent engine is the expensive failure; a
+    # needless swig install is the cheap one.
+    local defaults="ansible/roles/ovos_virtualenv/defaults/main.yml"
+    local constraints="ansible/roles/ovos_virtualenv/tasks/constraints.yml"
+
+    run grep -q "^ovos_virtualenv_needs_fann2: true$" "$defaults"
+    assert_success
+
+    # The major-version lookup falls back to 1 when nothing matches.
+    run grep -q "default('1')" "$constraints"
+    assert_success
+
+    run grep -q "failed_when: false" "$constraints"
+    assert_success
 }

--- a/tests/bats/code_quality.bats
+++ b/tests/bats/code_quality.bats
@@ -3575,3 +3575,31 @@ function teardown() {
     run grep -q "failed_when: false" "$constraints"
     assert_success
 }
+
+@test "scenarios_assert_an_intent_engine_survived_the_install" {
+    # padatious reaches the venv only through an ovos-core extra, so it can be
+    # dropped without any task failing - the install reports failed=0 and has
+    # no intent engine. Structure tests catch a changed gate; only a
+    # post-install assertion catches a changed resolution.
+    local script=".github/scripts/assert_intent_engine.sh"
+
+    run test -x "$script"
+    assert_success
+
+    run grep -q "ovos-padatious" "$script"
+    assert_success
+
+    # The fann2 expectation must come from the installed padatious, not from a
+    # channel name, or it goes stale the moment stable moves to a 2.x core.
+    # Comments may name channels to explain that; the code may not branch on
+    # one, so only non-comment lines are checked.
+    run bash -c "grep -vE '^[[:space:]]*#' \"$script\" | grep -qE '\\b(stable|testing|alpha)\\b'"
+    assert_failure
+
+    # Every workflow that installs into a virtualenv has to run it.
+    local workflow
+    for workflow in macos_ci scenarios-archlinux scenarios-ubuntu2404; do
+        run grep -q "assert_intent_engine.sh" ".github/workflows/${workflow}.yml"
+        assert_success
+    done
+}


### PR DESCRIPTION
Supersedes #587, which had the right observation but the wrong conclusion.

## The problem

`ovos-core[lgpl]` is what pulls `ovos-padatious`, and on the 1.x line that drags in `fann2` — compiled from source, needing `swig` and the FANN headers, and carrying a whole `swig2.0` shim to survive swig 4.5 dropping the Python 2 macros. padatious 2.x dropped fann2 and moved itself into the `plugins` extra, so on a 3.x core `lgpl` resolves to nothing and only earns `does not have an extra named lgpl`.

Resolved against the live per-channel constraints (uv, py3.12):

| channel | core | `[lgpl,plugins]` | `[plugins]` |
| --- | --- | --- | --- |
| stable | 1.3.x | 86 pkgs, padatious 1.4.3, **fann2 1.0.7** | 81 pkgs, neither |
| testing | 2.1.x | 86 pkgs, padatious 1.4.3, **fann2 1.0.7** | 81 pkgs, neither |
| alpha | 3.2.2a1 | 96 pkgs, padatious 2.0.16a1, no fann2 | **96 pkgs, identical** |

The extra cannot simply be dropped: on stable and testing it is the only thing that requests padatious, and no requirements template asks for it explicitly, so removing it takes the intent engine with it — #587's CI shows this as `ModuleNotFoundError: No module named 'fann2'`. It also cannot be kept unconditionally, because alpha then builds a C extension it has no use for.

## The change

Both halves now follow one decision:

- **`tasks/constraints.yml`** (new) moves the constraints fetch ahead of the package tasks — the decision has to be made before anything is installed — and derives `ovos_virtualenv_needs_fann2` from the channel's own `ovos-padatious` pin. `venv.yml` still consumes the cached file, it just no longer fetches it.
- The `lgpl` extra in `core-requirements.txt.j2` and `server-requirements.txt.j2` follows the flag.
- `swig` and the FANN headers move out of the five distro lists into `ovos_virtualenv_fann2_packages_*`, composed back in only when needed. On Arch the AUR list held nothing but `fann`, so that step goes away entirely.
- The eight fann/swig tasks in `packages.yml` — the Homebrew dylib handling, the AUR install, and the swig2.0 shim — are gated on the same flag.

Keying on the **resolved pin** rather than the channel name means this flips on its own when stable and testing move to a padatious 2.x core, instead of needing an edit. That was the brittleness worth avoiding: a channel-name switch would have to be hunted down across five package lists and a shim.

Fail-safe direction is deliberate: a missing or unreadable constraints file falls back to building fann2. A needless swig install is the cheap failure; a silently missing intent engine is the expensive one.

## Verification

Ran `constraints.yml` end to end against the real constraints files:

```
channel=stable  needs_fann2=True  debian_swig=['swig', 'libfann-dev'] aur=['fann']
channel=testing needs_fann2=True  debian_swig=['swig', 'libfann-dev'] aur=['fann']
channel=alpha   needs_fann2=False debian_swig=[]                      aur=[]
```

Both templates render `ovos-core[lgpl,plugins]` and `ovos-core[plugins]` under the two decisions. `ansible-lint` passes the production profile; `site.yml` syntax-checks; 162/162 `code_quality.bats` pass.

Arch CI is unaffected — `run_virtualenv_role.sh` pins `channel=testing`, so it still builds fann2 against swig 4.5 and `from fann2 import libfann` still holds.

## Tests

Five new tests, each negative-tested by reintroducing the regression it targets:

- fann/swig tasks must carry the guard **in their own `when:`** — using the same when-scoped parser as the container-exec guard, since a variable named in a task title or comment gates nothing at runtime
- base package lists must carry no fann2 build dependency, and each family must still have a `fann2_packages_*` list
- neither template may hardcode the extra
- `constraints.yml` must be imported before `packages.yml`, and `venv.yml` must not fetch twice
- the decision must fail safe toward building fann2

I did not add per-channel assertions to CI on purpose: hardcoding "stable implies fann2" would fail spuriously the moment upstream moves stable to a 2.x core, which is precisely the edit this design avoids. The no-fann2 path is exercised by the existing nightly alpha matrix and the macOS alpha jobs.

## Risk

The one thing worth a second opinion: `swig` was added for fann2 specifically, but if any other source build in the alpha set quietly relies on it being present, that would surface only on an alpha install. The nightly alpha matrix is what would catch it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Virtual environment setup now adapts FANN2-related dependencies to the installed Padatious version.
  - Newer Padatious versions avoid unnecessary FANN2 build requirements, while older versions retain required compatibility support.
  - Installation checks now confirm that the Padatious intent engine remains available and functional across supported scenarios.

- **Tests**
  - Expanded automated coverage verifies dependency selection, compatibility behavior, and intent-engine availability after installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->