### PR TITLE
feat: default intent pipeline to ovos-m2v-pipeline, drop padatious

### DIFF
--- a/ansible/roles/ovos_config/templates/mycroft.conf.j2
+++ b/ansible/roles/ovos_config/templates/mycroft.conf.j2
@@ -110,7 +110,6 @@
       "ovos-converse-pipeline-plugin",
       "ovos-ocp-pipeline-plugin-high",
       "ovos-persona-pipeline-plugin-high",
-      "ovos-padatious-pipeline-plugin-high",
       "ovos-m2v-pipeline-high",
       "ovos-fallback-pipeline-plugin-high",
       "ovos-adapt-pipeline-plugin-high",


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

## What

Mirrors the OpenVoiceOS/ovos-config default-pipeline change (draft PR: https://github.com/OpenVoiceOS/ovos-config/pull/321) in the config the installer writes for a fresh box: `ovos-m2v-pipeline` becomes the primary intent matcher tier, and `ovos-padatious-pipeline-plugin` is dropped from the installed pipeline.

## Change

`ansible/roles/ovos_config/templates/mycroft.conf.j2` — removed `ovos-padatious-pipeline-plugin-high` from the `intents.pipeline` list the installer renders into a fresh `mycroft.conf`. `ovos-m2v-pipeline-high` already sat right after it, ahead of Adapt, so it is now the first classifier tier tried.

No package-list change was needed: `ovos-core[plugins]` (installed by `core-requirements.txt.j2`) already depends on `ovos-m2v-pipeline`, so the plugin is already present on every install. The intent-model config itself (which repo id `ovos_m2v_pipeline` points at) is not set in this template — it inherits ovos-config's own shipped default, which pull/321 points at `OpenVoiceOS/ovos-m2v-intents-multi-128M-v5` in classifier mode.

## Found but left alone — needs a decision

`ansible/roles/ovos_virtualenv/tasks/intent_cache.yml` (wired in unconditionally from `venv.yml`) clones `https://github.com/OpenVoiceOS/padatious_cache` and syncs a pretrained padatious intent cache into `~/.local/share/mycroft/intent_cache` on every install. That is padatious-specific infrastructure that becomes dead weight once padatious is not the default engine, but removing it is a bigger, separate call than reordering the pipeline list (it is a whole role/feature, not a one-line default). Left untouched pending a decision on whether to disable, gate behind a flag, or remove it outright.

## Testing

Template change is a single line removed from a Jinja list; no ansible lint/molecule run was performed locally. Relying on repo CI plus the OVOS orchestrator's live-test gate before merge.
