### PR TITLE
fix(containers): quote .env values so Compose cannot rewrite them

### DIFF
--- a/ansible/roles/ovos_containers/templates/docker/env.j2
+++ b/ansible/roles/ovos_containers/templates/docker/env.j2
@@ -1,60 +1,73 @@
 #jinja2: lstrip_blocks: True
+{#- Compose interpolates unquoted .env values, so a value holding a $ (a password,
+    a path) is silently replaced by whatever that looks like - usually nothing - and
+    " VAL # x" is truncated at the comment. Single quotes are literal to Compose;
+    a value containing a single quote falls back to double quotes, where the escape
+    sequences and $$ are what Compose expects. -#}
+{%- macro env(value) -%}
+{%- set text = value | string -%}
+{%- if "'" in text -%}
+"{{ text | replace('\\', '\\\\') | replace('"', '\\"') | replace('$', '$$') }}"
+{%- else -%}
+'{{ text }}'
+{%- endif -%}
+{%- endmacro -%}
 {% if ovos_installer_display_server != 'N/A' %}
-DISPLAY={{ ovos_installer_display_server_number if ovos_installer_display_server_number is defined else ovos_containers_display_default }}
+DISPLAY={{ env(ovos_installer_display_server_number if ovos_installer_display_server_number is defined else ovos_containers_display_default) }}
 {% endif %}
 {% if 'gpio' in getent_group %}
-GPIO_GID={{ getent_group['gpio'][1] }}
+GPIO_GID={{ env(getent_group['gpio'][1]) }}
 {% endif %}
 {% if ovos_installer_profile != 'ovos' %}
-HIVEMIND_CONFIG_FOLDER={{ ovos_containers_hivemind_config_dir }}
-HIVEMIND_CONFIG_PHAL_FOLDER={{ ovos_containers_hivemind_config_phal_dir }}
-HIVEMIND_SHARE_FOLDER={{ ovos_containers_hivemind_share_dir }}
-HIVEMIND_USER={{ ovos_containers_hivemind_user }}
+HIVEMIND_CONFIG_FOLDER={{ env(ovos_containers_hivemind_config_dir) }}
+HIVEMIND_CONFIG_PHAL_FOLDER={{ env(ovos_containers_hivemind_config_phal_dir) }}
+HIVEMIND_SHARE_FOLDER={{ env(ovos_containers_hivemind_share_dir) }}
+HIVEMIND_USER={{ env(ovos_containers_hivemind_user) }}
 {% endif %}
 {% if 'i2c' in getent_group %}
-I2C_GID={{ getent_group['i2c'][1] }}
+I2C_GID={{ env(getent_group['i2c'][1]) }}
 {% endif %}
 {% if 'input' in getent_group %}
-INPUT_GID={{ getent_group['input'][1] }}
+INPUT_GID={{ env(getent_group['input'][1]) }}
 {% endif %}
-OVOS_CONFIG_FOLDER={{ ovos_containers_ovos_config_dir }}
-OVOS_CONFIG_PHAL_FOLDER={{ ovos_containers_ovos_config_phal_dir }}
-OVOS_PERSONA_FOLDER={{ ovos_containers_ovos_persona_dir }}
-OVOS_SHARE_FOLDER={{ ovos_containers_ovos_share_dir }}
-OVOS_USER={{ ovos_containers_ovos_user }}
-PULL_POLICY={{ ovos_containers_docker_pull_policy }}
+OVOS_CONFIG_FOLDER={{ env(ovos_containers_ovos_config_dir) }}
+OVOS_CONFIG_PHAL_FOLDER={{ env(ovos_containers_ovos_config_phal_dir) }}
+OVOS_PERSONA_FOLDER={{ env(ovos_containers_ovos_persona_dir) }}
+OVOS_SHARE_FOLDER={{ env(ovos_containers_ovos_share_dir) }}
+OVOS_USER={{ env(ovos_containers_ovos_user) }}
+PULL_POLICY={{ env(ovos_containers_docker_pull_policy) }}
 {% if "Raspberry Pi 5" in (ovos_installer_raspberrypi | default('')) and ovos_installer_display_server == "N/A" %}
-QT_QPA_EGLFS_INTEGRATION={{ ovos_containers_qt_qpa_eglfs_integration_pi5 }}
+QT_QPA_EGLFS_INTEGRATION={{ env(ovos_containers_qt_qpa_eglfs_integration_pi5) }}
 {% elif ovos_installer_display_server == "N/A" %}
-QT_QPA_EGLFS_INTEGRATION={{ ovos_containers_qt_qpa_eglfs_integration_default }}
+QT_QPA_EGLFS_INTEGRATION={{ env(ovos_containers_qt_qpa_eglfs_integration_default) }}
 {% endif %}
 {% if "Raspberry Pi 5" in (ovos_installer_raspberrypi | default('')) and ovos_installer_display_server == "N/A" %}
-QT_QPA_EGLFS_KMS_CONFIG={{ ovos_containers_qt_qpa_eglfs_kms_config }}
+QT_QPA_EGLFS_KMS_CONFIG={{ env(ovos_containers_qt_qpa_eglfs_kms_config) }}
 {% endif %}
-QT_QPA_PLATFORM={{ ovos_containers_qt_qpa_platform_headless if ovos_installer_display_server == "N/A" else ovos_containers_qt_qpa_platform_gui }}
+QT_QPA_PLATFORM={{ env(ovos_containers_qt_qpa_platform_headless if ovos_installer_display_server == "N/A" else ovos_containers_qt_qpa_platform_gui) }}
 {% if 'render' in getent_group %}
-RENDER_GID={{ getent_group['render'][1] }}
+RENDER_GID={{ env(getent_group['render'][1]) }}
 {% endif %}
 {% if 'spi' in getent_group %}
-SPI_GID={{ getent_group['spi'][1] }}
+SPI_GID={{ env(getent_group['spi'][1]) }}
 {% endif %}
-TMP_FOLDER={{ ovos_containers_tmp_dir }}
+TMP_FOLDER={{ env(ovos_containers_tmp_dir) }}
 {% if ovos_timezone_value is defined %}
-TZ={{ ovos_timezone_value }}
+TZ={{ env(ovos_timezone_value) }}
 {% else %}
-TZ={{ ovos_containers_timezone_default }}
+TZ={{ env(ovos_containers_timezone_default) }}
 {% endif %}
-VERSION={{ ovos_containers_docker_image_tag }}
+VERSION={{ env(ovos_containers_docker_image_tag) }}
 {% if 'video' in getent_group %}
-VIDEO_GID={{ getent_group['video'][1] }}
+VIDEO_GID={{ env(getent_group['video'][1]) }}
 {% endif %}
 {% if ovos_installer_profile == 'satellite' %}
-VOICE_SAT_KEY={{ ovos_installer_satellite_key }}
-VOICE_SAT_PASSWORD={{ ovos_installer_satellite_password }}
-VOICE_SAT_HOST={{ ovos_containers_voice_sat_protocol }}://{{ ovos_installer_listener_host }}
-VOICE_SAT_PORT={{ ovos_installer_listener_port | default(ovos_containers_listener_port_default) }}
+VOICE_SAT_KEY={{ env(ovos_installer_satellite_key) }}
+VOICE_SAT_PASSWORD={{ env(ovos_installer_satellite_password) }}
+VOICE_SAT_HOST={{ env(ovos_containers_voice_sat_protocol ~ '://' ~ ovos_installer_listener_host) }}
+VOICE_SAT_PORT={{ env(ovos_installer_listener_port | default(ovos_containers_listener_port_default)) }}
 {% endif %}
 {% if ovos_installer_display_server != 'N/A' %}
-WAYLAND_DISPLAY={{ ovos_installer_wayland_display if ovos_installer_wayland_display is defined else ovos_containers_wayland_display_default }}
+WAYLAND_DISPLAY={{ env(ovos_installer_wayland_display if ovos_installer_wayland_display is defined else ovos_containers_wayland_display_default) }}
 {% endif %}
-XDG_RUNTIME_DIR={{ ovos_containers_xdg_runtime_dir }}
+XDG_RUNTIME_DIR={{ env(ovos_containers_xdg_runtime_dir) }}


### PR DESCRIPTION
## What this explains

A user reported their satellite container crash-looping after a containers install ([hivemind-docker#45](https://github.com/JarbasHiveMind/hivemind-docker/pull/45) fixed the resulting confusion), with `hivemind-voice-sat` falling into ggwave audio pairing — the branch it takes when the password is **empty**. But the installer asserts a non-empty satellite password before it runs anything, so where did it go?

It is lost on the way into `.env`. Compose applies interpolation to unquoted values ([documented](https://docs.docker.com/compose/how-tos/environment-variables/variable-interpolation/): *"Unquoted and double-quoted values have interpolation applied"*), and `env.j2` writes every value unquoted.

## Measured, by rendering the template and parsing the result under Compose's rules

| password | before | after |
| --- | --- | --- |
| `P@ss$word123` | **`P@ss`** | `P@ss$word123` |
| `$USER` | **`HOSTUSER`** (the host's own variable) | `$USER` |
| `trail # note` | **`trail`** | `trail # note` |
| `has#hash` | `has#hash` | `has#hash` |
| `back\slash` | `back\slash` | `back\slash` |
| `it's-quoted` | `it's-quoted` | `it's-quoted` |

The first row is the reported failure: a password containing `$` arrives truncated, the client sends the wrong secret or none at all. The second is worse than truncation — a host variable is substituted into a credential.

Auto-generated credentials are safe (`hivemind-core add-client` uses `os.urandom(16).hex()`), which is why this only bites people who type their own password — and the strength check now in `add-client` encourages exactly the kind of password that contains `$`.

## The fix

A small `env()` macro wraps every value in single quotes, which Compose takes literally. A value containing a single quote falls back to double quotes with `\\`, `\"` and `$$` escaped as Compose expects. Applied to all 32 assignments, not just the secrets, so paths and timezones are covered too.

## Verified

Rendered the real template with `ansible-playbook` for each case above and parsed the output with Compose's documented rules (single-quoted literal, double-quoted escapes + interpolation, unquoted interpolation with ` #` comments) — every value round-trips, and the same test against `main` reproduces the three failures. `ansible-lint` passes on the production profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Docker Compose environment values containing special characters.
  * Prevented dollar signs from being interpreted unexpectedly and ensured values containing hashes or quotes are preserved correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->