### PR TITLE
chore(ci): pin every workflow action to an immutable commit

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -24,7 +24,7 @@ jobs:
     name: Verify pinned contracts
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
 

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -41,15 +41,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.14"
 
       - name: Restore Python/uv/Ansible caches
-        uses: actions/cache@v6.1.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/.cache/pip
@@ -77,7 +77,7 @@ jobs:
           ansible-playbook --list-tasks ansible/site.yml > artifacts/list-tasks-site
 
       - name: Upload Ansible artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: ansible-artifacts
           path: artifacts
@@ -86,10 +86,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Run yaml-lint
-        uses: ibiqlik/action-yamllint@v3
+        uses: ibiqlik/action-yamllint@2576378a8e339169678f9939646ee3ee325e845c # v3
         with:
           config_file: ansible/.yamllint
 
@@ -97,10 +97,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Run ShellCheck
-        uses: ludeeus/action-shellcheck@2.0.0
+        uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # 2.0.0
         env:
           SHELLCHECK_OPTS: -x -s bash -e SC1091
 
@@ -108,10 +108,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Run actionlint
-        uses: rhysd/actionlint@v1.7.12
+        uses: rhysd/actionlint@914e7df21a07ef503a81201c76d2b11c789d3fca # v1.7.12
 
   ansible-syntax-matrix:
     runs-on: ubuntu-latest
@@ -177,15 +177,15 @@ jobs:
             needs_satellite: false
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.14"
 
       - name: Restore Python/uv/Ansible caches
-        uses: actions/cache@v6.1.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/.cache/pip

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -42,6 +42,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
@@ -87,6 +89,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Run yaml-lint
         uses: ibiqlik/action-yamllint@2576378a8e339169678f9939646ee3ee325e845c # v3
@@ -98,6 +102,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Run ShellCheck
         uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # 2.0.0
@@ -109,6 +115,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Run actionlint
         uses: rhysd/actionlint@914e7df21a07ef503a81201c76d2b11c789d3fca # v1.7.12
@@ -178,6 +186,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7

--- a/.github/workflows/macos_ci.yml
+++ b/.github/workflows/macos_ci.yml
@@ -44,6 +44,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Decide whether macOS jobs are needed
@@ -93,6 +94,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
@@ -146,6 +149,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Install macOS installer requirements
         run: |

--- a/.github/workflows/macos_ci.yml
+++ b/.github/workflows/macos_ci.yml
@@ -42,7 +42,7 @@ jobs:
       scenarios: ${{ steps.matrix.outputs.scenarios }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 
@@ -92,15 +92,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.14"
 
       - name: Restore Python/uv/Ansible caches
-        uses: actions/cache@v6.1.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/Library/Caches/pip
@@ -145,14 +145,14 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install macOS installer requirements
         run: |
           brew install bash jq expect newt
 
       - name: Restore installer caches
-        uses: actions/cache@v6.1.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/Library/Caches/pip

--- a/.github/workflows/scenarios-archlinux.yml
+++ b/.github/workflows/scenarios-archlinux.yml
@@ -51,6 +51,8 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Report distribution toolchain
         run: |

--- a/.github/workflows/scenarios-archlinux.yml
+++ b/.github/workflows/scenarios-archlinux.yml
@@ -50,7 +50,7 @@ jobs:
         run: pacman -Syu --noconfirm --needed base-devel git python python-pip sudo
 
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Report distribution toolchain
         run: |

--- a/.github/workflows/scenarios-ubuntu2404.yml
+++ b/.github/workflows/scenarios-ubuntu2404.yml
@@ -45,7 +45,7 @@ jobs:
       run: ${{ steps.platform.outputs.run }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
           fetch-depth: 0
@@ -82,12 +82,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
 
       - name: Restore installer caches
-        uses: actions/cache@v6.1.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/.cache/pip
@@ -227,12 +227,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
 
       - name: Restore installer caches
-        uses: actions/cache@v6.1.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/.cache/pip
@@ -387,12 +387,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
 
       - name: Restore installer caches
-        uses: actions/cache@v6.1.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/.cache/pip
@@ -514,12 +514,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
 
       - name: Restore installer caches
-        uses: actions/cache@v6.1.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/.cache/pip
@@ -614,7 +614,7 @@ jobs:
 
       - name: Upload key-role idempotency logs
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: role-idempotency-logs
           path: artifacts
@@ -664,7 +664,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
 
@@ -729,7 +729,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
 

--- a/.github/workflows/shell_testing.yml
+++ b/.github/workflows/shell_testing.yml
@@ -45,7 +45,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install BATS requirements
         run: |

--- a/.github/workflows/shell_testing.yml
+++ b/.github/workflows/shell_testing.yml
@@ -46,6 +46,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Install BATS requirements
         run: |

--- a/.github/workflows/sync_tx.yml
+++ b/.github/workflows/sync_tx.yml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: main
           fetch-depth: 0 # otherwise, there would be errors pushing refs to the destination repository.
       - name: Setup Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: 3.14
       - name: Run script if manual dispatch
@@ -32,7 +32,7 @@ jobs:
         run: |
           python scripts/sync_translations.py
       - name: Commit to main
-        uses: stefanzweifel/git-auto-commit-action@v7
+        uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v7
         with:
           commit_message: Update translations
           branch: main

--- a/.github/workflows/sync_tx.yml
+++ b/.github/workflows/sync_tx.yml
@@ -4,6 +4,10 @@ concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: false
 
+# Pushes the generated locales back to main, so it needs contents: write - and only that.
+permissions:
+  contents: write
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/telemetry_charts.yml
+++ b/.github/workflows/telemetry_charts.yml
@@ -26,10 +26,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.14"
 
@@ -37,7 +37,7 @@ jobs:
         run: python3 scripts/render_telemetry_charts.py
 
       - name: Commit when the numbers moved
-        uses: stefanzweifel/git-auto-commit-action@v7
+        uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v7
         with:
           commit_message: "chore(docs): refresh telemetry charts"
           file_pattern: docs/images/telemetry-*.svg

--- a/tests/bats/code_quality.bats
+++ b/tests/bats/code_quality.bats
@@ -3497,7 +3497,7 @@ function anchors_of() {
 }
 
 @test "ci_restores_python_uv_and_collection_caches" {
-    run grep -F -q "uses: actions/cache@v6" .github/workflows/linting.yml
+    run grep -E -q "uses: actions/cache@[0-9a-f]{40} # v6" .github/workflows/linting.yml
     assert_success
 
     run grep -F -q "~/.cache/uv" .github/workflows/linting.yml
@@ -3769,4 +3769,18 @@ function teardown() {
     # Every workflow must go through it rather than calling apt-get update directly.
     run bash -c "command grep -rn 'sudo apt-get update' .github/workflows/ | command grep -v apt_update.sh"
     assert_failure
+}
+
+@test "workflow_actions_are_pinned_to_an_immutable_commit" {
+    # A tag is not immutable: whoever owns the action can move v7 to any commit, and every
+    # workflow here would run it on the next push - with the repository checked out and, in
+    # some jobs, a token available. The version stays on the line as a comment so the pin is
+    # still readable; Renovate updates both together.
+    run bash -c "command grep -rhoE 'uses: [a-zA-Z0-9._-]+/[a-zA-Z0-9._/-]+@[^ ]+' .github/workflows/*.yml \
+        | command grep -vE '@[0-9a-f]{40}'"
+    if [ -n "$output" ]; then
+        echo "these actions are pinned to a movable ref:" >&2
+        echo "$output" >&2
+    fi
+    assert_output ""
 }

--- a/tests/bats/code_quality.bats
+++ b/tests/bats/code_quality.bats
@@ -3776,8 +3776,22 @@ function teardown() {
     # workflow here would run it on the next push - with the repository checked out and, in
     # some jobs, a token available. The version stays on the line as a comment so the pin is
     # still readable; Renovate updates both together.
-    run bash -c "command grep -rhoE 'uses: [a-zA-Z0-9._-]+/[a-zA-Z0-9._/-]+@[^ ]+' .github/workflows/*.yml \
-        | command grep -vE '@[0-9a-f]{40}'"
+    # awk, not grep: the first version of this matched a single space after "uses:" and
+    # then filtered lines *containing* 40 hex characters anywhere, so "uses:  x/y@v7" was
+    # never extracted and a trailing comment could satisfy the filter. A guard with a hole
+    # in it is worse than none, because it reads as proof.
+    run awk '
+        match($0, /uses:[[:space:]]+[A-Za-z0-9._-]+\/[A-Za-z0-9._\/-]+@[^[:space:]#]+/) {
+            ref = substr($0, RSTART, RLENGTH)
+            sub(/^uses:[[:space:]]+/, "", ref)
+            version = ref
+            sub(/^[^@]*@/, "", version)
+            if (version !~ /^[0-9a-f]{40}$/) {
+                print FILENAME ": " ref
+            }
+        }
+    ' .github/workflows/*.yml
+
     if [ -n "$output" ]; then
         echo "these actions are pinned to a movable ref:" >&2
         echo "$output" >&2


### PR DESCRIPTION
Follow-up to a review finding on #597, done repository-wide rather than in one file.

## Why

A tag is not immutable. Whoever owns an action can move `v7` to any commit, and every workflow here would run it on the next push — with the repository checked out and, in several jobs, a token available. That is [CWE-494](https://cwe.mitre.org/data/definitions/494.html), and it needs no compromise of this repository to happen.

Forty references across eight actions were on movable tags:

```
20  actions/checkout@v7                        5  actions/setup-python@v7
 8  actions/cache@v6.1.0                       2  actions/upload-artifact@v7
 2  stefanzweifel/git-auto-commit-action@v7    1  rhysd/actionlint@v1.7.12
 1  ludeeus/action-shellcheck@2.0.0            1  ibiqlik/action-yamllint@v3
```

The four third-party ones carry the most risk; `git-auto-commit-action` runs with write access in `sync_tx.yml`.

## Why not in #597

The finding was raised against `contracts.yml`, and I deliberately left it: pinning one of twenty references is inconsistency, not hardening, and it deserved to be reviewed as a policy rather than smuggled into a PR about something else.

It also matches the sibling repository — ovos-docker already pins by SHA, and its `actions/checkout` pin resolves to the same commit this one does, which was a useful cross-check that the resolution is right.

## Shape

Each reference becomes `owner/repo@<40-char sha> # <version>`. The version stays visible as a comment, and Renovate updates the SHA and the comment together, so this does not freeze the actions in place.

## Tests

`workflow_actions_are_pinned_to_an_immutable_commit` rejects any reference that is not a 40-character commit, so a new workflow cannot reintroduce a floating tag. Negative-tested by putting `actions/checkout@v7` back:

```
these actions are pinned to a movable ref:
uses: actions/checkout@v7
```

One existing test asserted the literal string `uses: actions/cache@v6` and now matches the SHA plus the version comment.

169/169 bats, `ansible-lint` clean on the production profile, every workflow still parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security and Reliability**
  * Pinned CI automation actions to immutable versions, improving build reproducibility and supply-chain stability.
  * Limited credential persistence and restricted workflow permissions while preserving existing automation behavior.

* **Tests**
  * Added validation to ensure workflow actions remain pinned to immutable commit references.
  * Updated cache-related checks to reflect the new pinned action versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->