### PR TITLE
ci: install the contract parser by artifact hash

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -28,9 +28,10 @@ jobs:
         with:
           persist-credentials: false
 
-      # version-pinned: this job reads a file fetched from another repository, so the
-      # tool that parses it should not change under us between runs
-      - run: pip install --disable-pip-version-check "pyyaml==6.0.2"
+      # hash-pinned: this job reads a file fetched from another repository, so the tool that
+      # parses it should not change under us between runs. The digests live in the requirements
+      # file, so the pin holds against the artifact and not just the version label.
+      - run: pip install --disable-pip-version-check --require-hashes -r scripts/contracts-requirements.txt
 
       - name: Check the installer against the contracts at the pinned refs
         env:

--- a/scripts/contracts-requirements.txt
+++ b/scripts/contracts-requirements.txt
@@ -1,0 +1,16 @@
+# Dependencies for scripts/check_contracts.py, pinned by version and by artifact hash.
+#
+# This job reads files fetched from other repositories, so the tool that parses them must not
+# change under us between runs. --require-hashes makes that a property of the artifact rather
+# than of the index: a version pin alone still trusts whatever PyPI serves for that version.
+#
+# The digests cover the sdist and the manylinux x86_64 wheels for the Python versions a
+# ubuntu-24.04 runner may ship. To refresh, read the sha256 digests from
+# https://pypi.org/pypi/PyYAML/<version>/json - pip picks whichever artifact fits the runner and
+# fails closed if its digest is not listed here.
+pyyaml==6.0.2 \
+    --hash=sha256:ec031d5d2feb36d1d1a24380e4db6d43695f3748343d99434e6f5f9156aaa2ed \
+    --hash=sha256:3ad2a3decf9aaba3d29c8f537ac4b243e36bef957511b4766cb0057d32b0be85 \
+    --hash=sha256:80bab7bfc629882493af4aa31a4cfa43a4c57c83813253626916b8c7ada83476 \
+    --hash=sha256:70b189594dbe54f75ab3a1acec5f1e3faa7e8cf2f1e08d9b561cb41b845f69d5 \
+    --hash=sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e

--- a/tests/bats/code_quality.bats
+++ b/tests/bats/code_quality.bats
@@ -3798,3 +3798,35 @@ function teardown() {
     fi
     assert_output ""
 }
+
+@test "contracts_workflow_installs_its_parser_by_artifact_hash" {
+    # The same reasoning as the action pin, one layer down. This job parses files fetched from
+    # other repositories, so the parser is part of what the check trusts. A version pin still
+    # takes whatever the index serves for that version; --require-hashes makes the pin hold
+    # against the artifact, and fails closed when it does not match.
+    run grep -F -q -- "--require-hashes -r scripts/contracts-requirements.txt" \
+        .github/workflows/contracts.yml
+    assert_success
+
+    # every requirement is version-pinned and carries at least one digest of its own, or pip
+    # would refuse the file at install time rather than here. Counting digests across the whole
+    # file would let one well-hashed requirement vouch for an unhashed one added after it, so
+    # each requirement is tracked as its own stanza: a name==version line opens one and the
+    # continuation lines that follow belong to it.
+    run awk '
+        /^[[:space:]]*#/ { next }
+        /^[A-Za-z0-9._-]+[[:space:]]*==/ {
+            if (name != "" && hashes == 0) { print "no digest for " name }
+            name = $0
+            sub(/[[:space:]].*$/, "", name)
+            pinned++
+            hashes = 0
+        }
+        /--hash=sha256:[0-9a-f]{64}/ { if (name != "") hashes++ }
+        END {
+            if (name != "" && hashes == 0) { print "no digest for " name }
+            if (pinned < 1) { print "no version-pinned requirement found" }
+        }
+    ' scripts/contracts-requirements.txt
+    assert_output ""
+}


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 5 (1M context) via Claude Code — NOT human-reviewed. Verify before acting.

The upstream-contracts job parses files it fetches from other repositories, so the parser is part of what the check trusts. It was installed as `pyyaml==6.0.2`, which pins the version label but still accepts whatever the index serves under it. The pin now holds against the artifact: the digests live in `scripts/contracts-requirements.txt` and pip installs with `--require-hashes`, so a substituted artifact fails the job instead of parsing the contracts.

The digests cover the sdist and the manylinux x86_64 wheels for the Python versions a `ubuntu-24.04` runner may ship, and pip picks whichever fits. Both paths are exercised: the wheel on 3.12, and the sdist fallback on a 3.14 interpreter, where no wheel for that version exists. A tampered digest is refused rather than warned about.

`contracts_workflow_installs_its_parser_by_artifact_hash` keeps it that way, next to the action-pin test that makes the same argument one layer up. It asserts the workflow installs through the requirements file and that every requirement there is version-pinned with a digest; reverting the workflow line fails it.

One half of the original report is already satisfied and needs no change: `actions/checkout` is pinned to a commit SHA, and `workflow_actions_are_pinned_to_an_immutable_commit` has been enforcing that for every workflow in the repository. `GH_TOKEN` also stays, because the `--online` check cannot fetch the contracts without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved the reliability and security of contract-related dependency installation by using a hash-verified requirements configuration.
  - Ensured the parser dependency remains pinned to an approved version and package artifacts.

- **Tests**
  - Added automated validation to confirm dependency versions and SHA-256 hashes are consistently enforced during contract workflow runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->