### PR TITLE
feat: check that the images an install pulls match the compose it runs

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -33,7 +33,12 @@ jobs:
       # file, so the pin holds against the artifact and not just the version label.
       - run: pip install --disable-pip-version-check --require-hashes -r scripts/contracts-requirements.txt
 
+      # The image half asks the producer's own bake graph which build target an image belongs
+      # to, rather than guessing from its name. `bake --print` needs the buildx CLI but neither a
+      # daemon nor the network.
+      - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
+
       - name: Check the installer against the contracts at the pinned refs
         env:
           GH_TOKEN: ${{ github.token }}
-        run: python3 scripts/check_contracts.py --online --fail-on-stale
+        run: python3 scripts/check_contracts.py --online --fail-on-stale --fail-on-image-drift

--- a/scripts/check_contracts.py
+++ b/scripts/check_contracts.py
@@ -11,8 +11,9 @@ those repositories and this one, and all four have broken an install:
   environment          every variable the compose reads must come from env.j2 - or, for a variable
                        with an inline default, must come from env.j2 anyway when the installer is
                        the one that owns the value
-  images               the compose is pinned by tag, the images move with a channel tag, so an
-                       image can be older than the compose that expects it
+  images               the compose is pinned by tag, the images move with a channel tag, so a
+                       published image can be older than the compose that expects it - or newer
+                       and expecting something the pinned compose does not provide
 
 The third is the one that stays quiet. A compose file that starts reading HIVEMIND_SITEID keeps
 working: it just uses the literal string "default" instead of the site id collected here. Nothing
@@ -20,8 +21,8 @@ fails, and every satellite reports the wrong site. That is why a contract marks 
 `owner: installer` and why this refuses to treat "has a default" as "nobody needs to set it".
 
 Offline by default, against the snapshots in tests/contracts/, so this runs in any pull request.
---online re-fetches them at the pinned refs, reports a pin that has fallen behind a release, and
-checks that the published images are not older than the compose pinned here.
+--online re-fetches them at the pinned refs and reports a pin that has fallen behind a release.
+The image half is NOT checked here: see scripts/image_coherence.py, which --online calls.
 """
 import argparse
 import json

--- a/scripts/check_contracts.py
+++ b/scripts/check_contracts.py
@@ -28,12 +28,16 @@ import argparse
 import json
 import re
 import subprocess
+import tempfile
 import sys
 import urllib.error
 import urllib.request
 from pathlib import Path
 
 import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import image_coherence  # noqa: E402  (same directory, not a package)
 
 DEPENDENCY_BUMP = re.compile(r"^(chore\(deps\)|Update .+ to v|build\(deps\)|chore: update .+ digest)", re.I)
 
@@ -62,6 +66,7 @@ def installer_facts() -> dict:
     compose = dict(re.findall(r"^(ovos_containers_compose_file_[a-z_]+):\s*(\S+)$", containers, re.M))
     containers_named = dict(re.findall(r"^(ovos_containers_container_[a-z_]+):\s*(\S+)$", containers, re.M))
     pins = dict(re.findall(r"^ovos_installer_(ovos|hivemind)_docker_repo_branch:\s*(\S+)$", installer, re.M))
+    channel = re.search(r"^ovos_installer_channel:\s*[\"']?([A-Za-z0-9._-]+)", installer, re.M)
     urls = dict(re.findall(r"^ovos_installer_(ovos|hivemind)_docker_repo_url:\s*(\S+)$", installer, re.M))
 
     files = {"hivemind-docker": set(), "ovos-docker": set()}
@@ -74,6 +79,7 @@ def installer_facts() -> dict:
         "container_names": set(containers_named.values()),
         "provided_env": set(re.findall(r"^([A-Z][A-Z0-9_]*)=", ENV_TEMPLATE.read_text(), re.M)),
         "pins": {"ovos-docker": pins.get("ovos"), "hivemind-docker": pins.get("hivemind")},
+        "channel": channel.group(1) if channel else "testing",
         "slugs": {k: re.sub(r"^https://github\.com/|\.git$", "", v)
                   for k, v in {"ovos-docker": urls.get("ovos", ""),
                                "hivemind-docker": urls.get("hivemind", "")}.items()},
@@ -199,6 +205,11 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--online", action="store_true",
                         help="re-fetch the contracts at the pinned refs and check pin freshness")
+    parser.add_argument("--fail-on-image-drift", action="store_true",
+                        help="treat an image that disagrees with the pinned compose as a failure. "
+                             "Separate from --fail-on-stale because it depends on a registry and "
+                             "on the producer's rebuild schedule, so it can go red for reasons a "
+                             "pin bump cannot fix.")
     parser.add_argument("--fail-on-stale", action="store_true",
                         help="treat a pin behind the latest release as a failure. A scheduled run "
                              "that exits 0 tells nobody anything, so the job that watches for "
@@ -253,6 +264,18 @@ def main() -> int:
         problems.extend(check(repo, contract, facts))
 
     problems.extend(check_containers(contracts, facts))
+
+    if args.online:
+        # Clones go to a temporary directory, never inside the repository: a checkout of another
+        # project under ROOT gets picked up by this repository's own linters and tests.
+        with tempfile.TemporaryDirectory(prefix="ovos-contract-pins-") as cache:
+            image_problems, image_notes, coverage = image_coherence.check_images(
+                contracts, facts, Path(cache), facts["channel"])
+        # Printed unconditionally: a run that resolved nothing must not look like a clean one.
+        for (repo, tag), (resolved, total) in sorted(coverage.items()):
+            print(f"images checked: {repo}@{tag} {resolved}/{total}")
+        notes.extend(image_notes)
+        (problems if args.fail_on_image_drift else notes).extend(image_problems)
 
     for note in notes:
         print(f"note: {note}")

--- a/scripts/image_coherence.py
+++ b/scripts/image_coherence.py
@@ -1,0 +1,374 @@
+#!/usr/bin/env python3
+"""Check that the images an install pulls agree with the compose files it runs.
+
+The containers method takes its compose files from a git tag and its images from a channel tag
+that keeps moving. Those two can disagree, and when they do the failure is remote from its cause:
+a compose file expects behaviour the published image does not have, and the install breaks with a
+traceback about something else entirely.
+
+The hard part is not detecting a difference, it is deciding whether the difference matters. An
+image is rebuilt whenever the channel's constraints move, with no commit in this repository at
+all, so its revision sits behind the tag permanently and legitimately. "Image revision is older
+than the pinned ref" is therefore not a defect - it is the normal state.
+
+So the question asked here is narrower: between the image's revision and the pinned ref, did
+anything change that would have rebuilt THIS image? That question already has an authoritative
+answer in the producer's own scripts/affected.py, the selector its CI uses to decide what to
+rebuild. Running that, in a checkout at the pinned ref, means this check and the publisher cannot
+disagree about what affects an image - rather than this file inventing a second opinion that
+drifts.
+
+Labels are read from the GHCR mirror over the anonymous registry API. Docker Hub would work too
+and is where the installer actually pulls from, but its unauthenticated budget is ~100 manifest
+requests per hour per IP, shared across everything on a runner's egress - so using it here would
+break other jobs rather than this one.
+"""
+import concurrent.futures
+import json
+import re
+import subprocess
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+import yaml
+
+REGISTRY_TIMEOUT = 20
+TAG_VAR = re.compile(r":\$\{?[A-Za-z_][A-Za-z0-9_]*\}?$")
+
+
+def canonical_image(image: str) -> str:
+    """Drop the tag variable and give the repository an explicit registry.
+
+    Kept identical to contract.py's function of the same name so the two agree on what an image
+    is called; the compose files spell the same registry both with and without docker.io/.
+    """
+    repository = TAG_VAR.sub("", image)
+    host = repository.split("/", 1)[0]
+    if "." not in host and ":" not in host and host != "localhost":
+        repository = f"docker.io/{repository}"
+    return repository
+
+
+def run(args, cwd=None, check=True):
+    return subprocess.run(args, cwd=cwd, capture_output=True, text=True, check=check)
+
+
+def pin_clone(slug: str, ref: str, cache: Path):
+    """A blobless clone of the producer at the pinned ref.
+
+    Blobless because every question here is answered by trees and history - which paths changed,
+    which commit is an ancestor - and never by file contents outside compose/, which `git show`
+    fetches on demand. Full clone of ovos-docker is ~14MB; this is ~1MB.
+    """
+    target = cache / slug.replace("/", "_")
+    if not target.exists():
+        run(["git", "clone", "--filter=blob:none", "--quiet",
+             f"https://github.com/{slug}", str(target)])
+    run(["git", "-C", str(target), "checkout", "--quiet", ref])
+    return target
+
+
+def deployed_images(clone: Path, ref: str, compose_names) -> dict:
+    """Images the installer actually pulls: every service in the compose files it runs.
+
+    Scope comes from the compose files rather than from the contract's `images` list, because the
+    contract lists everything the producer builds while an install runs a profile-selected subset.
+    Checking what is not deployed would report drift nobody can experience.
+    """
+    found = {}
+    for name in sorted(compose_names):
+        try:
+            body = run(["git", "-C", str(clone), "show", f"{ref}:compose/{name}"]).stdout
+        except subprocess.CalledProcessError:
+            continue
+        for service, spec in (yaml.safe_load(body).get("services") or {}).items():
+            if isinstance(spec, dict) and spec.get("image"):
+                found.setdefault(canonical_image(spec["image"]), {})[name] = service
+    return found
+
+
+def read_labels(path: str, tag: str):
+    """(labels, outcome) for ghcr.io/<path>:<tag>. outcome: ok | no_tag | denied | transport.
+
+    The outcomes are kept apart on purpose. "The tag is not there" is a finding; "we could not
+    reach the registry" is not, and collapsing them is how a check ends up reporting failure as
+    success.
+    """
+    def get(url, headers=None, accept=None):
+        request = urllib.request.Request(url, headers=headers or {})
+        if accept:
+            request.add_header("Accept", accept)
+        with urllib.request.urlopen(request, timeout=REGISTRY_TIMEOUT) as response:
+            return json.loads(response.read().decode())
+
+    manifest_types = ("application/vnd.oci.image.index.v1+json,"
+                      "application/vnd.docker.distribution.manifest.list.v2+json,"
+                      "application/vnd.oci.image.manifest.v1+json,"
+                      "application/vnd.docker.distribution.manifest.v2+json")
+    try:
+        token = get(f"https://ghcr.io/token?service=ghcr.io&scope=repository:{path}:pull")["token"]
+        auth = {"Authorization": f"Bearer {token}"}
+        manifest = get(f"https://ghcr.io/v2/{path}/manifests/{tag}", auth, manifest_types)
+
+        if "manifests" in manifest:
+            # An index carries attestation manifests whose config blob is literally {} - reading
+            # those reports "no revision" for every multi-arch image, so take a real platform.
+            digests = [m["digest"] for m in manifest["manifests"]
+                       if (m.get("platform") or {}).get("architecture") not in (None, "unknown")]
+            if not digests:
+                return None, "no_tag"
+            manifest = get(f"https://ghcr.io/v2/{path}/manifests/{digests[0]}", auth, manifest_types)
+
+        config_digest = (manifest.get("config") or {}).get("digest")
+        if not config_digest:
+            return None, "no_tag"
+        config = get(f"https://ghcr.io/v2/{path}/blobs/{config_digest}", auth)
+        # Labels can be null rather than absent.
+        return ((config.get("config") or {}).get("Labels") or {}), "ok"
+    except urllib.error.HTTPError as error:
+        if error.code == 404:
+            return None, "no_tag"
+        if error.code in (401, 403):
+            return None, "denied"
+        return None, "transport"
+    except Exception:
+        return None, "transport"
+
+
+def mirror_candidates(image: str, slugs: dict, declaring: str):
+    """GHCR paths to try for an image, the declaring repository's mirror first.
+
+    The mirror name is a convention from the producer's build workflow, declared in no contract,
+    so a miss here has to fall through to the next candidate rather than read as "no such image".
+    An image declared by one repository can be built by the other - ovos-docker's compose deploys
+    hivemind-cli - which is why the other pinned slug is tried too.
+    """
+    name = image.rsplit("/", 1)[-1]
+    ordered, seen = [], set()
+    for repo in [declaring] + [r for r in slugs if r != declaring]:
+        slug = (slugs.get(repo) or "").lower()
+        if slug and slug not in seen:
+            seen.add(slug)
+            ordered.append((repo, f"{slug}/{name}"))
+    return ordered
+
+
+def rebuild_targets(clone: Path, revision: str, pin: str):
+    """Targets the producer's own selector says a rev..pin diff would rebuild.
+
+    Returns (targets, reason). reason is None on success; anything else means the oracle could not
+    answer and the caller must say so rather than assume zero.
+    """
+    try:
+        run(["git", "-C", str(clone), "cat-file", "-e", f"{revision}^{{commit}}"])
+    except subprocess.CalledProcessError:
+        try:
+            run(["git", "-C", str(clone), "fetch", "--quiet", "origin", revision])
+        except subprocess.CalledProcessError:
+            return None, f"revision {revision[:12]} is not reachable in the repository"
+    try:
+        changed = run(["git", "-C", str(clone), "diff", "--name-only", revision, pin]).stdout
+    except subprocess.CalledProcessError as error:
+        return None, f"could not diff {revision[:12]}..{pin}: {error.stderr.strip()[:120]}"
+    if not changed.strip():
+        return [], None
+
+    selector = clone / "scripts" / "affected.py"
+    if not selector.exists():
+        return None, "the producer has no scripts/affected.py at this ref"
+    try:
+        result = subprocess.run(["python3", str(selector), "paths"], cwd=str(clone),
+                                input=changed, capture_output=True, text=True, check=True)
+        return json.loads(result.stdout), None
+    except Exception as error:
+        return None, f"the rebuild selector failed: {str(error)[:140]}"
+
+
+def target_images(clone: Path):
+    """image repository -> bake target, from the producer's own bake graph at this ref.
+
+    Needs the buildx CLI but no daemon and no network. Absent buildx is "cannot tell", never
+    "nothing is affected".
+    """
+    try:
+        printed = run(["docker", "buildx", "bake", "--print", "default"], cwd=str(clone)).stdout
+    except Exception:
+        return None
+    try:
+        graph = json.loads(printed)
+    except json.JSONDecodeError:
+        return None
+    mapping = {}
+    for target, body in (graph.get("target") or {}).items():
+        for tag in (body.get("tags") or []):
+            mapping[tag.rsplit(":", 1)[0]] = target
+    return mapping
+
+
+def service_interface(clone: Path, ref: str, compose_name: str, service: str):
+    """The part of a service definition an image has to agree with.
+
+    Environment keys, volume targets and the entrypoint/command: if the image moved ahead of the
+    compose and one of these changed, the running container is configured by a file that predates
+    what the image now expects. Values are deliberately excluded - they are the installer's to set.
+    """
+    try:
+        body = run(["git", "-C", str(clone), "show", f"{ref}:compose/{compose_name}"]).stdout
+    except subprocess.CalledProcessError:
+        return None
+    spec = ((yaml.safe_load(body) or {}).get("services") or {}).get(service)
+    if not isinstance(spec, dict):
+        return None
+    environment = spec.get("environment")
+    if isinstance(environment, dict):
+        keys = sorted(environment)
+    elif isinstance(environment, list):
+        keys = sorted(item.split("=", 1)[0] for item in environment if isinstance(item, str))
+    else:
+        keys = []
+    volumes = sorted(v.split(":")[1] for v in (spec.get("volumes") or [])
+                     if isinstance(v, str) and v.count(":") >= 1)
+    return {"environment": keys, "volumes": volumes,
+            "entrypoint": spec.get("entrypoint"), "command": spec.get("command")}
+
+
+def check_images(contracts: dict, facts: dict, cache: Path, channel: str):
+    """Compare what an install pulls against the compose it runs.
+
+    Returns (problems, notes, coverage). Nothing here is a problem unless it is both real and
+    actionable; everything unresolved is a note that names why, and the coverage counts are
+    printed by the caller so a run that verified nothing cannot look like a clean one.
+    """
+    problems, notes, coverage = [], [], {}
+    clones, oracles = {}, {}
+
+    for repo, contract in contracts.items():
+        slug, pin = facts["slugs"].get(repo), facts["pins"].get(repo)
+        if not slug or not pin:
+            notes.append(f"{repo}: no pin or repository url in the installer defaults")
+            continue
+        try:
+            clones[repo] = pin_clone(slug, pin, cache)
+        except Exception as error:
+            notes.append(f"{repo}: could not clone {slug} at {pin} ({str(error)[:90]}) - "
+                         f"no image was verified for it")
+            continue
+        oracles[repo] = target_images(clones[repo])
+        if oracles[repo] is None:
+            notes.append(f"{repo}: could not read the bake graph at {pin} (is docker buildx "
+                         f"installed?) - images cannot be attributed to a build target")
+
+    for repo, contract in contracts.items():
+        clone = clones.get(repo)
+        if clone is None:
+            continue
+        pin = facts["pins"][repo]
+        deployed = deployed_images(clone, pin, facts["compose_files"][repo])
+
+        declared = set(contract.get("images") or [])
+        for image in sorted(set(deployed) - declared):
+            problems.append(f"{repo}: the pinned compose deploys {image} but the contract does not "
+                            f"declare it - the producer's own contract gate missed it")
+
+        resolved = 0
+        for image in sorted(deployed):
+            labels, outcome, used_repo = None, "no_tag", None
+            for candidate_repo, path in mirror_candidates(image, facts["slugs"], repo):
+                labels, outcome = read_labels(path, channel)
+                if outcome == "ok":
+                    used_repo = candidate_repo
+                    break
+            if outcome != "ok":
+                reason = {"no_tag": f"no :{channel} tag published",
+                          "denied": "the mirror refused anonymous access",
+                          "transport": "the registry could not be reached"}[outcome]
+                notes.append(f"{repo}: {image} not verified - {reason}")
+                continue
+
+            revision = labels.get("org.opencontainers.image.revision")
+            source = (labels.get("org.opencontainers.image.source") or "").rsplit("github.com/", 1)[-1]
+            if not revision:
+                notes.append(f"{repo}: {image}:{channel} carries no revision label - not verified")
+                continue
+
+            # An image is judged against the repository that built it, which is not always the one
+            # whose compose deploys it: ovos-docker's compose runs hivemind-cli.
+            owner = next((r for r, s in facts["slugs"].items()
+                          if s and s.lower() == source.lower()), None)
+            if owner is None:
+                notes.append(f"{repo}: {image} is built by {source or 'an unknown repository'}, "
+                             f"which this installer does not pin - out of scope")
+                continue
+            owner_clone, owner_pin = clones.get(owner), facts["pins"].get(owner)
+            if owner_clone is None:
+                notes.append(f"{repo}: {image} is built by {owner}, which could not be cloned - "
+                             f"not verified")
+                continue
+
+            resolved += 1
+            verdict, detail = compare(owner_clone, owner_pin, revision, image,
+                                      oracles.get(owner), deployed[image], clone, pin)
+            if verdict == "behind":
+                problems.append(f"{repo}: {image}:{channel} was built from {revision[:12]}, which "
+                                f"predates {owner_pin} by changes that rebuild it ({detail}) - the "
+                                f"pinned compose expects an image this one is not")
+            elif verdict == "ahead":
+                problems.append(f"{repo}: {image}:{channel} was built from {revision[:12]}, which "
+                                f"is ahead of {owner_pin}, and {detail} - the image expects a "
+                                f"compose newer than the one pinned here")
+            elif verdict == "unknown":
+                notes.append(f"{repo}: {image} not verified - {detail}")
+
+        coverage[(repo, channel)] = (resolved, len(deployed))
+
+    return problems, notes, coverage
+
+
+def compare(clone: Path, pin: str, revision: str, image: str, oracle, placements, compose_clone, compose_pin):
+    """(verdict, detail). verdict: coherent | behind | ahead | unknown."""
+    try:
+        run(["git", "-C", str(clone), "cat-file", "-e", f"{revision}^{{commit}}"])
+    except subprocess.CalledProcessError:
+        try:
+            run(["git", "-C", str(clone), "fetch", "--quiet", "origin", revision])
+        except subprocess.CalledProcessError:
+            return "unknown", f"revision {revision[:12]} is not reachable in {clone.name}"
+
+    behind = subprocess.run(["git", "-C", str(clone), "merge-base", "--is-ancestor", revision, pin],
+                            capture_output=True).returncode == 0
+    ahead = subprocess.run(["git", "-C", str(clone), "merge-base", "--is-ancestor", pin, revision],
+                           capture_output=True).returncode == 0
+
+    if behind and ahead:
+        return "coherent", "built from the pinned tree"
+    if not behind and not ahead:
+        return "unknown", (f"revision {revision[:12]} and {pin} have diverged - neither contains "
+                           f"the other")
+
+    if behind:
+        if oracle is None:
+            return "unknown", "the bake graph was unavailable, so nothing could be attributed"
+        target = oracle.get(image)
+        if target is None:
+            return "unknown", (f"{image} has no bake target at {pin}, so whether it would be "
+                               f"rebuilt cannot be decided")
+        targets, reason = rebuild_targets(clone, revision, pin)
+        if reason:
+            return "unknown", reason
+        return ("behind", f"rebuilds {target}") if target in targets else ("coherent", "unaffected")
+
+    # Ahead: the image moved past the compose. What matters is whether the part of the service
+    # definition the image has to agree with changed underneath it.
+    changed = []
+    for compose_name, service in (placements or {}).items():
+        at_pin = service_interface(compose_clone, compose_pin, compose_name, service)
+        at_rev = service_interface(clone, revision, compose_name, service)
+        if at_pin is None or at_rev is None:
+            continue
+        for field in ("environment", "volumes", "entrypoint", "command"):
+            if at_pin.get(field) != at_rev.get(field):
+                changed.append(f"{service}.{field}")
+    if changed:
+        return "ahead", "its service definition changed since: " + ", ".join(sorted(set(changed)))
+    return "coherent", "ahead, but no service interface it depends on changed"

--- a/scripts/test_image_coherence.py
+++ b/scripts/test_image_coherence.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Offline tests for the image coherence decision logic.
+
+The check itself needs a registry, so these build a real throwaway git repository instead and
+drive the decisions that matter: which direction the image sits relative to the pin, whether the
+producer's own selector says this image would be rebuilt, and - the case that makes the whole
+thing worth having - that an image sitting behind the pin by a harmless commit stays quiet.
+
+Every guard here is asserted in both directions. A check that only ever passes proves nothing.
+"""
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import image_coherence as ic  # noqa: E402
+
+
+def git(repo, *args):
+    subprocess.run(["git", "-C", str(repo), *args], check=True,
+                   capture_output=True, text=True)
+
+
+def commit(repo, path, body, message):
+    target = repo / path
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(body)
+    git(repo, "add", "-A")
+    git(repo, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-q", "-m", message)
+    return subprocess.run(["git", "-C", str(repo), "rev-parse", "HEAD"],
+                          capture_output=True, text=True, check=True).stdout.strip()
+
+
+# A stand-in for the producer's selector: rebuilds "app" only when app/ changed. The real one is
+# scripts/affected.py in the producer repository; this asserts we drive it correctly, not that it
+# is correct - that is its own repository's tests.
+SELECTOR = """#!/usr/bin/env python3
+import json, sys
+files = [l.strip() for l in sys.stdin if l.strip()]
+print(json.dumps(sorted({"app" for f in files if f.startswith("app/")})))
+"""
+
+
+class ImageCoherence(unittest.TestCase):
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.repo = Path(self._tmp.name) / "producer"
+        self.repo.mkdir()
+        git(self.repo, "init", "-q")
+        commit(self.repo, "scripts/affected.py", SELECTOR, "selector")
+        self.base = commit(self.repo, "app/Dockerfile", "FROM scratch\n", "app")
+        self.docs_only = commit(self.repo, "README.md", "docs\n", "docs only")
+        self.app_change = commit(self.repo, "app/Dockerfile", "FROM scratch\nRUN true\n", "app change")
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    # --- canonical_image -------------------------------------------------------------------
+    def test_canonical_image_matches_the_producers_spelling(self):
+        self.assertEqual(ic.canonical_image("smartgic/ovos-core:${VERSION}"),
+                         "docker.io/smartgic/ovos-core")
+        self.assertEqual(ic.canonical_image("ghcr.io/openvoiceos/x:${VERSION}"),
+                         "ghcr.io/openvoiceos/x")
+        # a registry is recognised by the dot, not by a list of known hosts
+        self.assertEqual(ic.canonical_image("localhost:5000/x:${VERSION}"), "localhost:5000/x")
+
+    # --- the rebuild oracle ----------------------------------------------------------------
+    def test_a_harmless_commit_rebuilds_nothing(self):
+        """The case this check exists to stay quiet about."""
+        targets, reason = ic.rebuild_targets(self.repo, self.base, self.docs_only)
+        self.assertIsNone(reason)
+        self.assertEqual(targets, [])
+
+    def test_a_change_under_the_build_context_rebuilds_the_image(self):
+        targets, reason = ic.rebuild_targets(self.repo, self.docs_only, self.app_change)
+        self.assertIsNone(reason)
+        self.assertEqual(targets, ["app"])
+
+    def test_an_unreachable_revision_is_not_reported_as_clean(self):
+        targets, reason = ic.rebuild_targets(self.repo, "0" * 40, self.app_change)
+        self.assertIsNone(targets)
+        self.assertIn("not reachable", reason)
+
+    # --- direction -------------------------------------------------------------------------
+    def test_image_behind_by_a_harmless_commit_is_coherent(self):
+        verdict, detail = ic.compare(self.repo, self.docs_only, self.base,
+                                     "img", {"img": "app"}, {}, self.repo, self.docs_only)
+        self.assertEqual(verdict, "coherent", detail)
+
+    def test_image_behind_by_a_rebuilding_commit_is_flagged(self):
+        verdict, detail = ic.compare(self.repo, self.app_change, self.docs_only,
+                                     "img", {"img": "app"}, {}, self.repo, self.app_change)
+        self.assertEqual(verdict, "behind", detail)
+        self.assertIn("app", detail)
+
+    def test_built_from_the_pinned_tree_is_coherent(self):
+        verdict, _ = ic.compare(self.repo, self.app_change, self.app_change,
+                                "img", {"img": "app"}, {}, self.repo, self.app_change)
+        self.assertEqual(verdict, "coherent")
+
+    def test_missing_bake_target_is_unknown_not_clean(self):
+        """An image nothing can attribute must not be reported as verified."""
+        verdict, detail = ic.compare(self.repo, self.app_change, self.base,
+                                     "img", {}, {}, self.repo, self.app_change)
+        self.assertEqual(verdict, "unknown", detail)
+
+    def test_missing_bake_graph_is_unknown_not_clean(self):
+        verdict, detail = ic.compare(self.repo, self.app_change, self.base,
+                                     "img", None, {}, self.repo, self.app_change)
+        self.assertEqual(verdict, "unknown", detail)
+        self.assertIn("bake graph", detail)
+
+    def test_unreachable_revision_is_unknown(self):
+        verdict, detail = ic.compare(self.repo, self.app_change, "0" * 40,
+                                     "img", {"img": "app"}, {}, self.repo, self.app_change)
+        self.assertEqual(verdict, "unknown", detail)
+
+    # --- service interface (the ahead direction) -------------------------------------------
+    def test_service_interface_reports_keys_not_values(self):
+        compose = ("services:\n  svc:\n    image: x:${VERSION}\n"
+                   "    environment:\n      A: one\n      B: two\n"
+                   "    volumes:\n      - ./h:/container/path:ro\n")
+        rev = commit(self.repo, "compose/docker-compose.yml", compose, "compose")
+        face = ic.service_interface(self.repo, rev, "docker-compose.yml", "svc")
+        self.assertEqual(face["environment"], ["A", "B"])
+        self.assertEqual(face["volumes"], ["/container/path"])
+
+        # changing a VALUE is the installer's business and must not read as an interface change
+        same = compose.replace("A: one", "A: changed")
+        rev2 = commit(self.repo, "compose/docker-compose.yml", same, "value change")
+        self.assertEqual(ic.service_interface(self.repo, rev2, "docker-compose.yml", "svc"), face)
+
+        # adding a KEY is the image's business and must
+        more = compose.replace("      B: two\n", "      B: two\n      C: three\n")
+        rev3 = commit(self.repo, "compose/docker-compose.yml", more, "key added")
+        self.assertNotEqual(ic.service_interface(self.repo, rev3, "docker-compose.yml", "svc"), face)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/bats/code_quality.bats
+++ b/tests/bats/code_quality.bats
@@ -3830,3 +3830,27 @@ function teardown() {
     ' scripts/contracts-requirements.txt
     assert_output ""
 }
+
+@test "image_coherence_decision_logic_is_tested_offline" {
+    # The image check itself needs a registry, so its decisions are exercised against a
+    # throwaway git repository instead: which side of the pin an image sits on, whether the
+    # producer's own selector says it would be rebuilt, and that an image behind the pin by a
+    # harmless commit stays quiet. That last one is the whole reason the check is not simply
+    # "revision >= pinned ref" - images are rebuilt when constraints move, with no commit here
+    # at all, so being behind is the normal state rather than a defect.
+    run python3 -m unittest discover -s scripts -p "test_image_coherence.py" -q
+    assert_success
+}
+
+@test "online_checks_report_how_many_images_they_actually_verified" {
+    # A run that resolved nothing must not read like a clean one. The coverage line is printed
+    # unconditionally, and every unresolved image becomes a note naming why.
+    local script="scripts/check_contracts.py"
+
+    run grep -q "images checked:" "$script"
+    assert_success
+
+    # the outcomes stay distinct: a registry that could not be reached is not "no such tag"
+    run grep -qE "no_tag|denied|transport" scripts/image_coherence.py
+    assert_success
+}


### PR DESCRIPTION
Closes the fifth coupling in the cross-repo contract — the one that was declared and never checked.

## The gap

`contract.yml` has listed `images` since the contract landed, and `check_contracts.py` never read it. Worse, its docstring claimed `--online` verified them. That claim is corrected in its own commit at the head of this branch, before the code that makes it true.

Compose files come from a pinned git tag; images come from a **moving** channel tag. They can disagree, and when they do the install fails somewhere far from the cause — which is exactly how the `/home/ovos` report that started this work behaved.

## Why not "revision >= pinned ref"

Because it would be red every week until someone turned it off. An image is rebuilt whenever the channel's constraints move, with **no commit in the producer at all**, so its revision sits behind the tag permanently and legitimately. Today `ovos-core:testing` is 3 commits behind `v2.1.0` and entirely fine.

So the question asked is narrower: *between the image's revision and the pinned ref, did anything change that would have rebuilt **this** image?*

That already has an authoritative answer — the producer's own `scripts/affected.py`, the selector its CI uses to decide what to rebuild, run in a blobless clone at the pinned ref. Reusing it means **this check and the publisher cannot hold different opinions** about what affects an image. On today's lag it returns `[]`, so the harmless case is quiet by construction rather than by a tuned exception list:

```
REAL LAG (13a248cc..v2.1.0)  -> targets=[]          # quiet
v2.0.2..v2.1.0               -> 31 targets          # docker-bake.hcl changed
bogus revision               -> cannot tell         # never "clean"
```

## It finds a real one on the first run

```
images checked: hivemind-docker@testing 2/2
images checked: ovos-docker@testing 28/28

hivemind-cli:testing / hivemind-listener:testing / hivemind-satellite:testing
  built from 6087d744, which predates v2.1.1 by changes that rebuild it
```

Verified independently: `base/Dockerfile` changed between `6087d744` and `v2.1.1` (a Renovate uv bump), and `base/` is the root of that repository's bake graph, so every image is rebuilt by it. **ovos-docker reports nothing** — its lag is the harmless one.

## Design notes

- **Ownership routing.** Images are attributed via `org.opencontainers.image.source`, because ovos-docker's compose deploys `hivemind-cli` and `hivemind-listener`, which hivemind-docker builds. Judging those against ovos-docker's pin would be nonsense.
- **The ahead direction** compares the service definition the image must agree with — environment *keys*, volume targets, entrypoint — ignoring values, which are the installer's to set.
- **GHCR, not Docker Hub.** Installs pull from Docker Hub, but its unauthenticated budget is ~100 manifest requests/hour/IP shared across a runner's egress; using it here would break *other* jobs. GHCR's anonymous token API has no such limit.
- **Attestation manifests** in a multi-arch index have a config blob of literally `{}` — walking every entry would report "no revision label" for every image. Only real platforms are read.
- **No silent success.** Coverage is printed unconditionally, an unreachable registry is a note naming the reason, and an image with no bake target is *cannot tell*, never *clean*.

Needs **no contract change and no new producer release** — it reads the compose files and bake graph already present at the pinned tags.

## Tests

`scripts/test_image_coherence.py` — 11 offline tests against a throwaway git repository, so PR CI needs no registry. Both directions asserted for every guard, including the one that matters most: *an image behind the pin by a harmless commit is coherent*. Also that a missing bake target, a missing bake graph and an unreachable revision are each **unknown rather than clean**, and that changing an environment *value* is not an interface change while adding a *key* is.

172/172 bats, `ansible-lint` clean, syntax verified on 3.11 (the interpreter the virtualenv scenarios use) as well as 3.14.

Escalation is behind `--fail-on-image-drift`, deliberately separate from `--fail-on-stale`: it can go red for reasons a pin bump cannot fix, and conflating them would make one alert unreadable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Contract verification now detects when container images have drifted from their expected build targets.
  * Image checks distinguish actionable mismatches from unresolved conditions such as missing tags, access restrictions, or registry failures.
  * Verification results now report image coverage counts, preventing runs with no verified images from appearing successful.

* **Tests**
  * Added coverage for image consistency checks and related edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->