### PR TITLE
fix: fail on release lag only when an install can see the difference

### DIFF
--- a/scripts/check_contracts.py
+++ b/scripts/check_contracts.py
@@ -218,6 +218,7 @@ def main() -> int:
 
     facts = installer_facts()
     problems, notes, contracts = [], [], {}
+    pending_lag = {}
 
     for repo in ("ovos-docker", "hivemind-docker"):
         snapshot = SNAPSHOTS / f"{repo}.yml"
@@ -249,11 +250,7 @@ def main() -> int:
 
             lag = release_lag(slug, newest or ref) if newest else None
             if lag and lag[0]:
-                behind, branch = lag
-                message = (f"{repo}: {newest or ref} is behind {branch} by {behind} "
-                           f"change(s) that are not dependency bumps - those fixes are in no "
-                           f"release, so no install has them")
-                (problems if args.fail_on_stale else notes).append(message)
+                pending_lag[repo] = (newest or ref, lag[0], lag[1])
             elif LAST_GH_ERROR:
                 # gh missing, unauthenticated or rate-limited looks exactly like "nothing is
                 # behind" unless it is reported, and then the run passes having checked nothing
@@ -271,6 +268,28 @@ def main() -> int:
         with tempfile.TemporaryDirectory(prefix="ovos-contract-pins-") as cache:
             image_problems, image_notes, coverage = image_coherence.check_images(
                 contracts, facts, Path(cache), facts["channel"])
+
+            # A release trailing its branch is only worth failing over when the commits in
+            # between are ones an install can observe. Asked with the producer's own selector,
+            # the same way the image half asks it.
+            for repo, (release, behind, branch) in sorted(pending_lag.items()):
+                clone = Path(cache) / (facts["slugs"][repo] or "").replace("/", "_")
+                if not clone.exists():
+                    notes.append(f"{repo}: {release} is behind {branch} by {behind} change(s); "
+                                 f"could not check whether an install sees them")
+                    continue
+                affects, detail = image_coherence.unreleased_impact(
+                    clone, release, branch, facts["compose_files"][repo])
+                if affects is None:
+                    notes.append(f"{repo}: {release} is behind {branch} by {behind} change(s); "
+                                 f"impact unknown ({detail})")
+                elif affects:
+                    message = (f"{repo}: {release} is behind {branch} by {behind} change(s) an "
+                               f"install would see ({detail}) - they are in no release")
+                    (problems if args.fail_on_stale else notes).append(message)
+                else:
+                    notes.append(f"{repo}: {release} is behind {branch} by {behind} change(s), "
+                                 f"but {detail} - no release needed for an install's sake")
         # Printed unconditionally: a run that resolved nothing must not look like a clean one.
         for (repo, tag), (resolved, total) in sorted(coverage.items()):
             print(f"images checked: {repo}@{tag} {resolved}/{total}")

--- a/scripts/image_coherence.py
+++ b/scripts/image_coherence.py
@@ -372,3 +372,40 @@ def compare(clone: Path, pin: str, revision: str, image: str, oracle, placements
     if changed:
         return "ahead", "its service definition changed since: " + ", ".join(sorted(set(changed)))
     return "coherent", "ahead, but no service interface it depends on changed"
+
+
+def unreleased_impact(clone: Path, tag: str, branch: str, compose_names):
+    """(affects, detail) for what sits on `branch` but not in `tag`.
+
+    A release trailing its branch only matters when the commits in between are ones an install
+    can observe: a compose file it runs, or a path that rebuilds an image it pulls. CI workflows,
+    tests and the contract tooling itself are substantive commits that change nothing a consumer
+    consumes, and failing a weekly job for those would teach people to ignore it - the same way a
+    naive image rule would have.
+    """
+    try:
+        run(["git", "-C", str(clone), "fetch", "--quiet", "origin", branch])
+        head = run(["git", "-C", str(clone), "rev-parse", "FETCH_HEAD"]).stdout.strip()
+        changed = run(["git", "-C", str(clone), "diff", "--name-only", tag, head]).stdout
+    except subprocess.CalledProcessError as error:
+        return None, f"could not compare {tag} with {branch}: {error.stderr.strip()[:110]}"
+
+    touched = [line for line in changed.splitlines() if line.strip()]
+    if not touched:
+        return False, "nothing"
+
+    compose_changed = sorted({line.split("/", 1)[1] for line in touched
+                              if line.startswith("compose/") and "/" in line
+                              and line.split("/", 1)[1] in compose_names})
+    targets, reason = rebuild_targets(clone, tag, head)
+    if reason:
+        return None, reason
+
+    if compose_changed or targets:
+        parts = []
+        if compose_changed:
+            parts.append("compose: " + ", ".join(compose_changed))
+        if targets:
+            parts.append(f"rebuilds {len(targets)} image(s)")
+        return True, "; ".join(parts)
+    return False, "only paths no install consumes"

--- a/scripts/test_image_coherence.py
+++ b/scripts/test_image_coherence.py
@@ -139,5 +139,54 @@ class ImageCoherence(unittest.TestCase):
         self.assertNotEqual(ic.service_interface(self.repo, rev3, "docker-compose.yml", "svc"), face)
 
 
+
+class UnreleasedImpact(unittest.TestCase):
+    """A release trailing its branch only matters when an install can see the difference."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.repo = Path(self._tmp.name) / "producer"
+        self.repo.mkdir()
+        git(self.repo, "init", "-q")
+        git(self.repo, "checkout", "-q", "-b", "dev")
+        commit(self.repo, "scripts/affected.py", SELECTOR, "selector")
+        commit(self.repo, "compose/docker-compose.yml", "services: {}\n", "compose")
+        commit(self.repo, "app/Dockerfile", "FROM scratch\n", "app")
+        git(self.repo, "tag", "v1.0.0")
+        # a clone cannot fetch from itself, so the tests point the function at this repo as both
+        git(self.repo, "remote", "add", "origin", str(self.repo))
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_ci_only_commits_do_not_warrant_a_release(self):
+        commit(self.repo, ".github/workflows/ci.yml", "on: push\n", "ci only")
+        commit(self.repo, "scripts/helper.py", "# tooling\n", "tooling only")
+        affects, detail = ic.unreleased_impact(self.repo, "v1.0.0", "dev", {"docker-compose.yml"})
+        self.assertFalse(affects, detail)
+        self.assertIn("no install consumes", detail)
+
+    def test_a_compose_change_an_install_runs_does_warrant_one(self):
+        commit(self.repo, "compose/docker-compose.yml", "services: {x: {}}\n", "compose change")
+        affects, detail = ic.unreleased_impact(self.repo, "v1.0.0", "dev", {"docker-compose.yml"})
+        self.assertTrue(affects, detail)
+        self.assertIn("docker-compose.yml", detail)
+
+    def test_a_compose_file_this_installer_does_not_run_is_ignored(self):
+        commit(self.repo, "compose/docker-compose.other.yml", "services: {}\n", "other compose")
+        affects, detail = ic.unreleased_impact(self.repo, "v1.0.0", "dev", {"docker-compose.yml"})
+        self.assertFalse(affects, detail)
+
+    def test_a_change_that_rebuilds_an_image_does_warrant_one(self):
+        commit(self.repo, "app/Dockerfile", "FROM scratch\nRUN true\n", "image change")
+        affects, detail = ic.unreleased_impact(self.repo, "v1.0.0", "dev", {"docker-compose.yml"})
+        self.assertTrue(affects, detail)
+        self.assertIn("rebuilds", detail)
+
+    def test_nothing_unreleased_is_not_an_impact(self):
+        affects, detail = ic.unreleased_impact(self.repo, "v1.0.0", "dev", {"docker-compose.yml"})
+        self.assertFalse(affects, detail)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
Follow-up to #603, closing the last false positive in the contract checks.

## The problem

The lag rule counted every non-dependency commit between the newest release and the branch it is cut from. Right now both producers are two commits behind, and in both cases those commits are:

```
fix(ci): publish from the last commit actually published
fix: read compose the way compose does in the contract gate
```

A CI workflow fix and a fix to the contract tooling. Substantive work — and completely invisible to an install. Asked directly, the producer's own selector agrees:

```
$ git diff --name-only v2.1.0 origin/dev | python3 scripts/affected.py paths
changed files: 4 -> targets: 0
[]
```

So the weekly job would have been red for them indefinitely. That is exactly how an alert stops being read, and it is the same false positive the image half was built to avoid — "changed, but cannot affect you".

## The change

Answered the same way as the image half, for the same reason: ask whether the unreleased commits **rebuild an image this installer pulls**, or **touch a compose file it runs**. Neither, and the lag becomes a note that says so:

```
note: ovos-docker: v2.1.0 is behind dev by 2 change(s), but only paths no install
      consumes - no release needed for an install's sake
```

`--fail-on-stale` now exits 0 with images clean and the lag explained, instead of red on work nobody could observe.

## It keeps its teeth

Five new tests against a throwaway git repository, asserting both directions rather than only the quiet one:

| case | warrants a release |
| --- | --- |
| CI-only and tooling-only commits | no |
| a compose file the installer **runs** changed | yes |
| a compose file it does **not** run changed | no |
| a change that rebuilds an image | yes |
| nothing unreleased | no |

An impact that cannot be determined is a note naming why — never silence. 16 tests in `scripts/test_image_coherence.py`, 172/172 bats, `ansible-lint` clean, 3.11 syntax verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved stale-release checks to evaluate changes only after repository data is available.
  - Release warnings now focus on changes that affect installer-used Compose configurations or require image rebuilds.
  - Unrelated tooling updates and changes to unused Compose files no longer trigger unnecessary release alerts.
  - Checks now distinguish between actionable changes, no-impact updates, and cases where impact cannot be determined.
  - Added clearer reporting when no new release is required.

- **Tests**
  - Added coverage for release-impact detection across relevant and unrelated change scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->