### PR TITLE
fix(containers): pin hivemind-docker v2.1.2

### DIFF
--- a/ansible/roles/ovos_installer/defaults/main.yml
+++ b/ansible/roles/ovos_installer/defaults/main.yml
@@ -70,7 +70,7 @@ ovos_installer_hivemind_docker_repo_url: https://github.com/JarbasHiveMind/hivem
 # hivemind_cli container - which composer.yml does - never reaches the satellite.
 # Pinned to a hivemind-docker release so satellite installs are reproducible, the
 # same way ovos-docker is above; bump on new releases.
-ovos_installer_hivemind_docker_repo_branch: v2.1.1
+ovos_installer_hivemind_docker_repo_branch: v2.1.2
 ovos_installer_docker_image_tag: "{{ ovos_installer_channel | default('testing') }}"
 ovos_installer_docker_pull_policy: always
 ovos_installer_docker_compose_remove_orphans: true


### PR DESCRIPTION
The contract check asked for this one, which is the first time it has driven a change rather than reported one.

## Why

Merging the `uv` 0.12.13 bump into hivemind-docker changed `base/Dockerfile` — the root of that bake graph — so every image was rebuilt. `v2.1.1` therefore stopped matching the images an install pulls, and the check said so:

```
violation: hivemind-docker: v2.1.1 is behind dev by 2 change(s) an install would see
           (rebuilds 8 image(s)) - they are in no release
note:      ovos-docker: v2.1.0 is behind dev by 2 change(s), but only paths no install
           consumes - no release needed for an install's sake
```

Two repositories, two unreleased commits each, opposite verdicts — because one set rebuilds images and the other is CI and tooling. That discrimination is what [#604](https://github.com/OpenVoiceOS/ovos-installer/pull/604) added, and this is it working on live data rather than a synthetic case.

## What v2.1.2 carries

- the fix that stops a **cancelled publish being dropped instead of retried** — the defect that left three images two days stale while every run stayed green
- the contract gate reading compose the way compose does (nested defaults, `:+`, lowercase names, `$$`)
- `uv` 0.12.13, with every image republished

The release was cut only after the publish finished, so the tag points at images that exist rather than opening a coherence gap in the other direction.

## Verification

The vendored snapshot is refreshed from the release itself — `v2.1.2` publishes `contract.yml`, so `--online` verifies against the real file instead of falling back to the snapshot. Full check after the bump:

```
images checked: hivemind-docker@testing 2/2
images checked: ovos-docker@testing 28/28
note: ovos-docker: ... only paths no install consumes - no release needed
contracts satisfied: ovos-docker v2.1.0, hivemind-docker v2.1.2
exit=0
```

172/172 bats, `ansible-lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Maintenance**
  * Updated the containers-mode installation to use the newer Hivemind Docker release, v2.1.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->