### PR TITLE
fix(contracts): report an image the run could not verify as unverified

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -23,6 +23,10 @@ jobs:
   contracts:
     name: Verify pinned contracts
     runs-on: ubuntu-24.04
+    # A healthy run takes a few minutes. An unreachable registry is retried, so a total outage
+    # costs three timeouts per image instead of one - without a bound that inherits the six-hour
+    # default and holds a runner all morning to reach a verdict this bound reaches anyway.
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -16,6 +16,7 @@ on:
       - ansible.cfg
       - ansible/**
       - utils/**
+      - scripts/**
       - setup.sh
       - installer.sh
       - tui/**
@@ -30,6 +31,7 @@ on:
       - ansible.cfg
       - ansible/**
       - utils/**
+      - scripts/**
       - setup.sh
       - installer.sh
       - tui/**
@@ -37,6 +39,28 @@ on:
   workflow_dispatch:
 
 jobs:
+  python-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Setup Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
+        with:
+          python-version: "3.14"
+
+      # Version-pinned so a new release cannot turn an unrelated pull request red. The repository
+      # had no Python linter at all until a dead import in the contract checker went unnoticed;
+      # ruff's default rules are the ones that catch that class without arguing about style.
+      - name: Install ruff
+        run: pip install --disable-pip-version-check ruff==0.15.12
+
+      - name: Run ruff
+        run: ruff check .
+
   ansible-lint:
     runs-on: ubuntu-latest
     steps:

--- a/scripts/check_contracts.py
+++ b/scripts/check_contracts.py
@@ -42,6 +42,11 @@ DEPENDENCY_BUMP = re.compile(
     r"^(chore\(deps\)|build\(deps\)|Update .+ to v|Update .+ digest to|chore: update .+ digest)",
     re.I)
 
+# A gh call that hangs is a gh call that failed: both leave the release lag unknown, and both
+# are already reported as such. Without this the only ceiling is the job's own timeout, which
+# reports nothing at all.
+GH_TIMEOUT = 120  # seconds
+
 LAST_GH_ERROR: list = []  # why a gh lookup came back empty, if it did
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -201,13 +206,14 @@ def release_lag(slug: str, tag: str) -> tuple[int, str] | None:
     try:
         branch = subprocess.run(["gh", "repo", "view", slug, "--json", "defaultBranchRef",
                                  "-q", ".defaultBranchRef.name"],
-                                capture_output=True, text=True, check=True).stdout.strip()
+                                capture_output=True, text=True, check=True,
+                                timeout=GH_TIMEOUT).stdout.strip()
         out = subprocess.run(["gh", "api", f"repos/{slug}/compare/{tag}...{branch}",
                               # single-parent only: a merge commit repeats what it merges,
                               # and counting it makes a lone dependency bump look substantive
                               "-q", ".commits[] | select(.parents | length == 1) "
                                     "| .commit.message | split(\"\\n\")[0]"],
-                             capture_output=True, text=True, check=True)
+                             capture_output=True, text=True, check=True, timeout=GH_TIMEOUT)
         # Only unreleased *fixes* are worth a release. Renovate merges dependency bumps
         # continuously, and failing a weekly job for those trains people to ignore it -
         # at which point the alert no longer works for the case it exists for.
@@ -223,7 +229,7 @@ def release_lag(slug: str, tag: str) -> tuple[int, str] | None:
 def latest_release(slug: str) -> str | None:
     try:
         out = subprocess.run(["gh", "release", "view", "--repo", slug, "--json", "tagName", "-q", ".tagName"],
-                             capture_output=True, text=True, check=True)
+                             capture_output=True, text=True, check=True, timeout=GH_TIMEOUT)
         return out.stdout.strip() or None
     except Exception as error:
         LAST_GH_ERROR.append(f"{type(error).__name__}: {error}")

--- a/scripts/check_contracts.py
+++ b/scripts/check_contracts.py
@@ -25,7 +25,6 @@ Offline by default, against the snapshots in tests/contracts/, so this runs in a
 The image half is NOT checked here: see scripts/image_coherence.py, which --online calls.
 """
 import argparse
-import json
 import re
 import subprocess
 import tempfile

--- a/scripts/check_contracts.py
+++ b/scripts/check_contracts.py
@@ -87,6 +87,34 @@ def installer_facts() -> dict:
     }
 
 
+def check_facts(facts: dict) -> list:
+    """Assert the facts exist at all, before anything is concluded from them.
+
+    Every fact above is pulled out of a file with a regular expression, and a checker holding no
+    facts finds no problems: indent these defaults under a key, rename a variable prefix, move
+    them to another file, and each pattern quietly matches nothing while the run reports
+    "contracts satisfied". A missing file raises, which is loud; a file that no longer matches
+    does not, which is not. Only things that cannot legitimately be empty are asserted here.
+    """
+    problems = []
+    for repo in ("ovos-docker", "hivemind-docker"):
+        if not facts["compose_files"].get(repo):
+            problems.append(f"{repo}: no compose file variables matched in "
+                            f"{CONTAINERS.relative_to(ROOT)} - nothing about this repository was "
+                            f"checked, so its contract was neither satisfied nor tested")
+        if not facts["pins"].get(repo):
+            problems.append(f"{repo}: no pin matched in {INSTALLER.relative_to(ROOT)}")
+        if not facts["slugs"].get(repo):
+            problems.append(f"{repo}: no repository url matched in {INSTALLER.relative_to(ROOT)}")
+    if not facts["container_names"]:
+        problems.append(f"no container names matched in {CONTAINERS.relative_to(ROOT)} - the "
+                        f"rename that this check exists to catch would now pass silently")
+    if not facts["provided_env"]:
+        problems.append(f"no variables matched in {ENV_TEMPLATE.relative_to(ROOT)} - every "
+                        f"variable upstream requires would read as supplied")
+    return problems
+
+
 def check(repo: str, contract: dict, facts: dict) -> list:
     problems = []
     wanted_files = facts["compose_files"][repo]
@@ -220,6 +248,8 @@ def main() -> int:
     facts = installer_facts()
     problems, notes, contracts = [], [], {}
     pending_lag = {}
+
+    problems.extend(check_facts(facts))
 
     for repo in ("ovos-docker", "hivemind-docker"):
         snapshot = SNAPSHOTS / f"{repo}.yml"

--- a/scripts/check_contracts.py
+++ b/scripts/check_contracts.py
@@ -39,7 +39,9 @@ import yaml
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 import image_coherence  # noqa: E402  (same directory, not a package)
 
-DEPENDENCY_BUMP = re.compile(r"^(chore\(deps\)|Update .+ to v|build\(deps\)|chore: update .+ digest)", re.I)
+DEPENDENCY_BUMP = re.compile(
+    r"^(chore\(deps\)|build\(deps\)|Update .+ to v|Update .+ digest to|chore: update .+ digest)",
+    re.I)
 
 LAST_GH_ERROR: list = []  # why a gh lookup came back empty, if it did
 
@@ -266,8 +268,13 @@ def main() -> int:
         # Clones go to a temporary directory, never inside the repository: a checkout of another
         # project under ROOT gets picked up by this repository's own linters and tests.
         with tempfile.TemporaryDirectory(prefix="ovos-contract-pins-") as cache:
-            image_problems, image_notes, coverage = image_coherence.check_images(
-                contracts, facts, Path(cache), facts["channel"])
+            try:
+                image_problems, image_notes, coverage = image_coherence.check_images(
+                    contracts, facts, Path(cache), facts["channel"])
+            except Exception as error:  # a crash here must be reported, not thrown away
+                image_problems = [f"the image check failed to run: "
+                                  f"{type(error).__name__}: {str(error)[:140]}"]
+                image_notes, coverage = [], {}
 
             # A release trailing its branch is only worth failing over when the commits in
             # between are ones an install can observe. Asked with the producer's own selector,
@@ -275,14 +282,16 @@ def main() -> int:
             for repo, (release, behind, branch) in sorted(pending_lag.items()):
                 clone = Path(cache) / (facts["slugs"][repo] or "").replace("/", "_")
                 if not clone.exists():
-                    notes.append(f"{repo}: {release} is behind {branch} by {behind} change(s); "
-                                 f"could not check whether an install sees them")
+                    (problems if args.fail_on_stale else notes).append(
+                        f"{repo}: {release} is behind {branch} by {behind} change(s) and whether "
+                        f"an install sees them could not be checked - no clone at {release}")
                     continue
                 affects, detail = image_coherence.unreleased_impact(
                     clone, release, branch, facts["compose_files"][repo])
                 if affects is None:
-                    notes.append(f"{repo}: {release} is behind {branch} by {behind} change(s); "
-                                 f"impact unknown ({detail})")
+                    (problems if args.fail_on_stale else notes).append(
+                        f"{repo}: {release} is behind {branch} by {behind} change(s) and their "
+                        f"impact could not be determined ({detail})")
                 elif affects:
                     message = (f"{repo}: {release} is behind {branch} by {behind} change(s) an "
                                f"install would see ({detail}) - they are in no release")
@@ -290,9 +299,18 @@ def main() -> int:
                 else:
                     notes.append(f"{repo}: {release} is behind {branch} by {behind} change(s), "
                                  f"but {detail} - no release needed for an install's sake")
-        # Printed unconditionally: a run that resolved nothing must not look like a clean one.
+        # Printed unconditionally, and asserted: a printed count nobody checks is decoration.
+        # Without this every "could not tell" outcome lands in notes, which can never fail the
+        # job, so a run that verified nothing ends green - the exact shape this check exists to
+        # catch elsewhere.
         for (repo, tag), (resolved, total) in sorted(coverage.items()):
-            print(f"images checked: {repo}@{tag} {resolved}/{total}")
+            print(f"images checked: {repo}@{tag} {resolved}/{total}"
+                  + ("" if total else " (not checked)"))
+            if resolved < total or not total:
+                missing = (total - resolved) if total else "all"
+                image_problems.append(
+                    f"{repo}@{tag}: {missing} of {total or 'its'} images reached no verdict - "
+                    f"the run did not establish that they match the pinned compose")
         notes.extend(image_notes)
         (problems if args.fail_on_image_drift else notes).extend(image_problems)
 

--- a/scripts/image_coherence.py
+++ b/scripts/image_coherence.py
@@ -82,7 +82,12 @@ def deployed_images(clone: Path, ref: str, compose_names) -> dict:
             body = run(["git", "-C", str(clone), "show", f"{ref}:compose/{name}"]).stdout
         except subprocess.CalledProcessError:
             continue
-        for service, spec in (yaml.safe_load(body).get("services") or {}).items():
+        try:
+            document = yaml.safe_load(body) or {}
+        except yaml.YAMLError:
+            # One unparseable file upstream must not discard every other answer in the run.
+            continue
+        for service, spec in (document.get("services") or {}).items():
             if isinstance(spec, dict) and spec.get("image"):
                 found.setdefault(canonical_image(spec["image"]), {})[name] = service
     return found
@@ -217,7 +222,11 @@ def service_interface(clone: Path, ref: str, compose_name: str, service: str):
         body = run(["git", "-C", str(clone), "show", f"{ref}:compose/{compose_name}"]).stdout
     except subprocess.CalledProcessError:
         return None
-    spec = ((yaml.safe_load(body) or {}).get("services") or {}).get(service)
+    try:
+        document = yaml.safe_load(body) or {}
+    except yaml.YAMLError:
+        return None
+    spec = (document.get("services") or {}).get(service)
     if not isinstance(spec, dict):
         return None
     environment = spec.get("environment")
@@ -244,15 +253,19 @@ def check_images(contracts: dict, facts: dict, cache: Path, channel: str):
     clones, oracles = {}, {}
 
     for repo, contract in contracts.items():
+        # Seeded before any early exit: a repository that drops out here would otherwise have no
+        # coverage line at all, so the report is emptiest exactly where it looks quietest.
+        coverage[(repo, channel)] = (0, 0)
         slug, pin = facts["slugs"].get(repo), facts["pins"].get(repo)
         if not slug or not pin:
-            notes.append(f"{repo}: no pin or repository url in the installer defaults")
+            problems.append(f"{repo}: no pin or repository url in the installer defaults - "
+                            f"no image was verified for it")
             continue
         try:
             clones[repo] = pin_clone(slug, pin, cache)
         except Exception as error:
-            notes.append(f"{repo}: could not clone {slug} at {pin} ({str(error)[:90]}) - "
-                         f"no image was verified for it")
+            problems.append(f"{repo}: could not clone {slug} at {pin} ({str(error)[:90]}) - "
+                            f"no image was verified for it")
             continue
         oracles[repo] = target_images(clones[repo])
         if oracles[repo] is None:
@@ -273,17 +286,24 @@ def check_images(contracts: dict, facts: dict, cache: Path, channel: str):
 
         resolved = 0
         for image in sorted(deployed):
-            labels, outcome, used_repo = None, "no_tag", None
-            for candidate_repo, path in mirror_candidates(image, facts["slugs"], repo):
+            labels, outcome, attempts = None, "no_tag", []
+            for _, path in mirror_candidates(image, facts["slugs"], repo):
                 labels, outcome = read_labels(path, channel)
                 if outcome == "ok":
-                    used_repo = candidate_repo
                     break
+                attempts.append(outcome)
             if outcome != "ok":
-                reason = {"no_tag": f"no :{channel} tag published",
-                          "denied": "the mirror refused anonymous access",
-                          "transport": "the registry could not be reached"}[outcome]
-                notes.append(f"{repo}: {image} not verified - {reason}")
+                # The candidates are tried in order, so the LAST one's outcome would otherwise
+                # decide: a registry that could not be reached would be reported as "no such tag".
+                outcome = next((o for o in ("transport", "denied", "no_tag") if o in attempts),
+                               "no_tag")
+                if outcome == "no_tag":
+                    problems.append(f"{repo}: the pinned compose deploys {image} but no :{channel} "
+                                    f"tag is published for it - an install pulling it would fail")
+                else:
+                    reason = ("the mirror refused anonymous access" if outcome == "denied"
+                              else "the registry could not be reached")
+                    notes.append(f"{repo}: {image} not verified - {reason}")
                 continue
 
             revision = labels.get("org.opencontainers.image.revision")
@@ -306,9 +326,12 @@ def check_images(contracts: dict, facts: dict, cache: Path, channel: str):
                              f"not verified")
                 continue
 
-            resolved += 1
             verdict, detail = compare(owner_clone, owner_pin, revision, image,
                                       oracles.get(owner), deployed[image], clone, pin)
+            # Counted only when a verdict was actually reached: "we read the labels" is not
+            # "we decided", and this number is the one thing that shows a run checked anything.
+            if verdict in ("coherent", "behind", "ahead"):
+                resolved += 1
             if verdict == "behind":
                 problems.append(f"{repo}: {image}:{channel} was built from {revision[:12]}, which "
                                 f"predates {owner_pin} by changes that rebuild it ({detail}) - the "
@@ -360,17 +383,30 @@ def compare(clone: Path, pin: str, revision: str, image: str, oracle, placements
 
     # Ahead: the image moved past the compose. What matters is whether the part of the service
     # definition the image has to agree with changed underneath it.
-    changed = []
+    changed, unreadable = [], []
     for compose_name, service in (placements or {}).items():
+        # The compose file belongs to the repository that DEPLOYS the image, which is not always
+        # the one that BUILT it: ovos-docker's docker-compose.hivemind.yml deploys hivemind-cli,
+        # and hivemind-docker has no such file. Reading it out of the builder's tree would always
+        # come back empty and silently read as agreement.
+        if clone != compose_clone:
+            unreadable.append(f"{compose_name}:{service} (built by another repository)")
+            continue
         at_pin = service_interface(compose_clone, compose_pin, compose_name, service)
         at_rev = service_interface(clone, revision, compose_name, service)
         if at_pin is None or at_rev is None:
+            unreadable.append(f"{compose_name}:{service}")
             continue
         for field in ("environment", "volumes", "entrypoint", "command"):
             if at_pin.get(field) != at_rev.get(field):
                 changed.append(f"{service}.{field}")
+
     if changed:
         return "ahead", "its service definition changed since: " + ", ".join(sorted(set(changed)))
+    if unreadable:
+        # Absence of evidence, not evidence of agreement.
+        return "unknown", ("ahead of the pin, and its service definition could not be compared for "
+                           + ", ".join(sorted(set(unreadable))))
     return "coherent", "ahead, but no service interface it depends on changed"
 
 
@@ -401,11 +437,15 @@ def unreleased_impact(clone: Path, tag: str, branch: str, compose_names):
     if reason:
         return None, reason
 
-    if compose_changed or targets:
-        parts = []
-        if compose_changed:
-            parts.append("compose: " + ", ".join(compose_changed))
+    if compose_changed:
+        detail = "compose: " + ", ".join(compose_changed)
         if targets:
-            parts.append(f"rebuilds {len(targets)} image(s)")
-        return True, "; ".join(parts)
+            detail += f"; also rebuilds {len(targets)} image(s)"
+        return True, detail
+    if targets:
+        # A rebuild reaches installs through the moving channel tag without any release, and
+        # whether that image then disagrees with the pinned compose is the image half's job.
+        # Demanding a release for it would be a weekly red for work already delivered.
+        return False, (f"only paths no install consumes; the {len(targets)} image(s) they rebuild "
+                       f"reach installs on the channel tag")
     return False, "only paths no install consumes"

--- a/scripts/image_coherence.py
+++ b/scripts/image_coherence.py
@@ -407,6 +407,14 @@ def check_images(contracts: dict, facts: dict, cache: Path, channel: str):
             # whose compose deploys it: ovos-docker's compose runs hivemind-cli.
             owner = next((r for r, s in facts["slugs"].items()
                           if s and s.lower() == source.lower()), None)
+            if owner is None and not source:
+                # An absent label is not a statement about who built this. It reads exactly like
+                # a third-party image and must not be treated as one: if a producer's build
+                # stopped emitting the label, every image would quietly leave the denominator
+                # and a run that checked nothing would pass. "Could not tell", so it counts.
+                notes.append(f"{repo}: {image}:{channel} names no source repository - it cannot "
+                             f"be attributed to a pin, so it was not verified")
+                continue
             if owner is None:
                 # Genuinely out of scope, so it leaves the denominator as well as the numerator.
                 # Every other unresolved outcome here means "could not tell" and must count
@@ -414,8 +422,8 @@ def check_images(contracts: dict, facts: dict, cache: Path, channel: str):
                 # fail the weekly job forever over an image nobody can do anything about - the
                 # note would say out of scope while the exit status said otherwise.
                 out_of_scope += 1
-                notes.append(f"{repo}: {image} is built by {source or 'an unknown repository'}, "
-                             f"which this installer does not pin - out of scope")
+                notes.append(f"{repo}: {image} is built by {source}, which this installer does "
+                             f"not pin - out of scope")
                 continue
             owner_clone, owner_pin = clones.get(owner), facts["pins"].get(owner)
             if owner_clone is None:

--- a/scripts/image_coherence.py
+++ b/scripts/image_coherence.py
@@ -27,6 +27,7 @@ import concurrent.futures
 import json
 import re
 import subprocess
+import time
 import urllib.error
 import urllib.request
 from pathlib import Path
@@ -34,6 +35,12 @@ from pathlib import Path
 import yaml
 
 REGISTRY_TIMEOUT = 20
+# A run reads ~30 images at three or four requests each. At that volume a single transient
+# failure is close to certain over time, and "the registry hiccuped" now fails the weekly
+# job - so a blip has to be told apart from an outage. Only transport failures are retried;
+# 404 and 401 are answers, and asking again just spends requests against a rate limit.
+REGISTRY_ATTEMPTS = 3
+REGISTRY_BACKOFF = 2  # seconds, doubled per attempt
 TAG_VAR = re.compile(r":\$\{?[A-Za-z_][A-Za-z0-9_]*\}?$")
 
 
@@ -93,7 +100,7 @@ def deployed_images(clone: Path, ref: str, compose_names) -> dict:
     return found
 
 
-def read_labels(path: str, tag: str):
+def _read_labels_once(path: str, tag: str):
     """(labels, outcome) for ghcr.io/<path>:<tag>. outcome: ok | no_tag | denied | transport.
 
     The outcomes are kept apart on purpose. "The tag is not there" is a finding; "we could not
@@ -139,6 +146,21 @@ def read_labels(path: str, tag: str):
         return None, "transport"
     except Exception:
         return None, "transport"
+
+
+def read_labels(path: str, tag: str, sleep=time.sleep):
+    """_read_labels_once, retrying a registry that could not be reached.
+
+    Retrying is not cosmetic here. An unreachable registry is a failure now rather than a note,
+    which is right for an outage and wrong for a hiccup: a job that goes red most weeks for
+    reasons nobody can act on gets muted, and then it protects nothing.
+    """
+    for attempt in range(REGISTRY_ATTEMPTS):
+        labels, outcome = _read_labels_once(path, tag)
+        if outcome != "transport" or attempt == REGISTRY_ATTEMPTS - 1:
+            return labels, outcome
+        sleep(REGISTRY_BACKOFF * (2 ** attempt))
+    return None, "transport"  # unreachable, kept so every path returns a pair
 
 
 def mirror_candidates(image: str, slugs: dict, declaring: str):

--- a/scripts/image_coherence.py
+++ b/scripts/image_coherence.py
@@ -40,6 +40,13 @@ REGISTRY_TIMEOUT = 20
 # 404 and 401 are answers, and asking again just spends requests against a rate limit.
 REGISTRY_ATTEMPTS = 3
 REGISTRY_BACKOFF = 2  # seconds, doubled per attempt
+# One wall-clock ceiling for every registry read a run makes, together. Each
+# candidate can cost REGISTRY_TIMEOUT * REGISTRY_ATTEMPTS plus its backoff -- 66
+# seconds -- and a run reads up to two candidates per deployed image, so a wide
+# outage scales past the job's own timeout. Being killed mid-check is the worst
+# outcome available: the run reports nothing at all, including the images it did
+# resolve. Past the budget the remaining reads are skipped and named instead.
+REGISTRY_BUDGET = 900  # seconds
 TAG_VAR = re.compile(r":\$\{?[A-Za-z_][A-Za-z0-9_]*\}?$")
 
 
@@ -75,28 +82,38 @@ def pin_clone(slug: str, ref: str, cache: Path):
     return target
 
 
-def deployed_images(clone: Path, ref: str, compose_names) -> dict:
+def deployed_images(clone: Path, ref: str, compose_names) -> tuple:
     """Images the installer actually pulls: every service in the compose files it runs.
 
     Scope comes from the compose files rather than from the contract's `images` list, because the
     contract lists everything the producer builds while an install runs a profile-selected subset.
     Checking what is not deployed would report drift nobody can experience.
+
+    Returns (images, unreadable). A compose file that could not be read or parsed is named in
+    `unreadable` rather than dropped: the run continues over the files it can read, but the
+    caller has to say so, because coverage computed over a silently smaller scope reads exactly
+    like coverage over the whole of it.
     """
-    found = {}
+    found, unreadable = {}, []
     for name in sorted(compose_names):
         try:
             body = run(["git", "-C", str(clone), "show", f"{ref}:compose/{name}"]).stdout
         except subprocess.CalledProcessError:
+            unreadable.append((name, "is not in the pinned tree"))
             continue
         try:
             document = yaml.safe_load(body) or {}
-        except yaml.YAMLError:
-            # One unparseable file upstream must not discard every other answer in the run.
+        except yaml.YAMLError as error:
+            # One unparseable file upstream must not discard every other answer in
+            # the run, but it must not quietly shrink what the run claims to cover
+            # either: the images it deploys go unchecked while coverage still reads
+            # complete, which is the one outcome this gate exists to prevent.
+            unreadable.append((name, f"is not valid YAML ({str(error)[:70]})"))
             continue
         for service, spec in (document.get("services") or {}).items():
             if isinstance(spec, dict) and spec.get("image"):
                 found.setdefault(canonical_image(spec["image"]), {})[name] = service
-    return found
+    return found, unreadable
 
 
 def _read_labels_once(path: str, tag: str):
@@ -147,16 +164,24 @@ def _read_labels_once(path: str, tag: str):
         return None, "transport"
 
 
-def read_labels(path: str, tag: str, sleep=time.sleep):
+def read_labels(path: str, tag: str, sleep=time.sleep, deadline=None):
     """_read_labels_once, retrying a registry that could not be reached.
 
     Retrying is not cosmetic here. An unreachable registry is a failure now rather than a note,
     which is right for an outage and wrong for a hiccup: a job that goes red most weeks for
     reasons nobody can act on gets muted, and then it protects nothing.
+
+    `deadline` is a monotonic instant shared by every read in the run. Past it no request is
+    made and no retry is waited out: the caller reports what is left as unverified rather than
+    being killed part-way through and reporting nothing.
     """
+    if deadline is not None and time.monotonic() >= deadline:
+        return None, "budget"
     for attempt in range(REGISTRY_ATTEMPTS):
         labels, outcome = _read_labels_once(path, tag)
         if outcome != "transport" or attempt == REGISTRY_ATTEMPTS - 1:
+            return labels, outcome
+        if deadline is not None and time.monotonic() >= deadline:
             return labels, outcome
         sleep(REGISTRY_BACKOFF * (2 ** attempt))
     return None, "transport"  # unreachable, kept so every path returns a pair
@@ -272,6 +297,8 @@ def check_images(contracts: dict, facts: dict, cache: Path, channel: str):
     """
     problems, notes, coverage = [], [], {}
     clones, oracles = {}, {}
+    deadline = time.monotonic() + REGISTRY_BUDGET
+    out_of_budget = 0
 
     for repo, contract in contracts.items():
         # Seeded before any early exit: a repository that drops out here would otherwise have no
@@ -298,7 +325,10 @@ def check_images(contracts: dict, facts: dict, cache: Path, channel: str):
         if clone is None:
             continue
         pin = facts["pins"][repo]
-        deployed = deployed_images(clone, pin, facts["compose_files"][repo])
+        deployed, unreadable = deployed_images(clone, pin, facts["compose_files"][repo])
+        for name, reason in unreadable:
+            problems.append(f"{repo}: compose/{name} {reason} - the images it deploys were "
+                            f"not checked, so this run's coverage is narrower than it looks")
 
         declared = set(contract.get("images") or [])
         for image in sorted(set(deployed) - declared):
@@ -309,15 +339,18 @@ def check_images(contracts: dict, facts: dict, cache: Path, channel: str):
         for image in sorted(deployed):
             labels, outcome, attempts = None, "no_tag", []
             for _, path in mirror_candidates(image, facts["slugs"], repo):
-                labels, outcome = read_labels(path, channel)
+                labels, outcome = read_labels(path, channel, deadline=deadline)
                 if outcome == "ok":
                     break
                 attempts.append(outcome)
             if outcome != "ok":
                 # The candidates are tried in order, so the LAST one's outcome would otherwise
                 # decide: a registry that could not be reached would be reported as "no such tag".
-                outcome = next((o for o in ("transport", "denied", "no_tag") if o in attempts),
-                               "no_tag")
+                outcome = next((o for o in ("budget", "transport", "denied", "no_tag")
+                                if o in attempts), "no_tag")
+                if outcome == "budget":
+                    out_of_budget += 1
+                    continue
                 if outcome == "no_tag":
                     problems.append(f"{repo}: the pinned compose deploys {image} but no :{channel} "
                                     f"tag is published for it - an install pulling it would fail")
@@ -365,6 +398,13 @@ def check_images(contracts: dict, facts: dict, cache: Path, channel: str):
                 notes.append(f"{repo}: {image} not verified - {detail}")
 
         coverage[(repo, channel)] = (resolved, len(deployed))
+
+    if out_of_budget:
+        # Named, not swallowed. These images were never asked about, so the
+        # coverage counts above already exclude them; saying how many were
+        # skipped is what stops a truncated run from reading like a thorough one.
+        notes.append(f"{out_of_budget} image(s) not verified - the {REGISTRY_BUDGET}s registry "
+                     f"budget for this run was spent before they were read")
 
     return problems, notes, coverage
 

--- a/scripts/image_coherence.py
+++ b/scripts/image_coherence.py
@@ -47,6 +47,12 @@ REGISTRY_BACKOFF = 2  # seconds, doubled per attempt
 # outcome available: the run reports nothing at all, including the images it did
 # resolve. Past the budget the remaining reads are skipped and named instead.
 REGISTRY_BUDGET = 900  # seconds
+# Every git, gh and docker call this program makes talks to a network or a daemon and none of
+# them carried a ceiling: a blackholed fetch simply never returns. The only bound was the job's
+# own timeout, and a job killed by that reports nothing at all - including the images it had
+# already resolved, which is the outcome the registry budget above exists to avoid. Generous
+# enough for a cold blobless clone of a large repository on a slow runner.
+SUBPROCESS_TIMEOUT = 300  # seconds
 TAG_VAR = re.compile(r":\$\{?[A-Za-z_][A-Za-z0-9_]*\}?$")
 
 
@@ -63,8 +69,23 @@ def canonical_image(image: str) -> str:
     return repository
 
 
-def run(args, cwd=None, check=True):
-    return subprocess.run(args, cwd=cwd, capture_output=True, text=True, check=check)
+def run(args, cwd=None, check=True, timeout=SUBPROCESS_TIMEOUT):
+    """subprocess.run, where hanging is reported as failing.
+
+    Every caller here already handles a command that fails; none of them could have handled one
+    that never returns. Raising CalledProcessError for a timeout puts both outcomes through the
+    same handler, which is right - "it did not answer" and "it answered badly" are the same
+    thing to a checker, and the alternative is an exception nobody catches.
+    """
+    try:
+        return subprocess.run(args, cwd=cwd, capture_output=True, text=True,
+                              check=check, timeout=timeout)
+    except subprocess.TimeoutExpired as expired:
+        # 124 is what timeout(1) reports, and stderr has to be a str because callers read it
+        raise subprocess.CalledProcessError(
+            124, args,
+            output=expired.stdout if isinstance(expired.stdout, str) else "",
+            stderr=f"no answer after {timeout}s") from expired
 
 
 def pin_clone(slug: str, ref: str, cache: Path):
@@ -89,12 +110,20 @@ def deployed_images(clone: Path, ref: str, compose_names) -> tuple:
     contract lists everything the producer builds while an install runs a profile-selected subset.
     Checking what is not deployed would report drift nobody can experience.
 
-    Returns (images, unreadable). A compose file that could not be read or parsed is named in
-    `unreadable` rather than dropped: the run continues over the files it can read, but the
-    caller has to say so, because coverage computed over a silently smaller scope reads exactly
-    like coverage over the whole of it.
+    Only images whose tag comes from the channel variable are in scope. This checker asks the
+    registry what `:<channel>` currently holds, so an image the compose pins itself - a fixed
+    tag, or none at all - is a question it cannot ask: the install pulls the tag written in the
+    compose, which is the tag it was pinned at, and a pinned image cannot drift. Asking about
+    `:<channel>` for one would look it up under a mirror that has no such tag and report that an
+    install pulling it would fail, which would be untrue and unfixable.
+
+    Returns (images, unreadable, self_pinned). A compose file that could not be read or parsed
+    is named in `unreadable` rather than dropped: the run continues over the files it can read,
+    but the caller has to say so, because coverage computed over a silently smaller scope reads
+    exactly like coverage over the whole of it. `self_pinned` is named for the same reason -
+    out of scope is a defensible answer, out of sight is not.
     """
-    found, unreadable = {}, []
+    found, unreadable, self_pinned = {}, [], []
     for name in sorted(compose_names):
         try:
             body = run(["git", "-C", str(clone), "show", f"{ref}:compose/{name}"]).stdout
@@ -112,8 +141,11 @@ def deployed_images(clone: Path, ref: str, compose_names) -> tuple:
             continue
         for service, spec in (document.get("services") or {}).items():
             if isinstance(spec, dict) and spec.get("image"):
+                if not TAG_VAR.search(spec["image"]):
+                    self_pinned.append((spec["image"], f"{name}:{service}"))
+                    continue
                 found.setdefault(canonical_image(spec["image"]), {})[name] = service
-    return found, unreadable
+    return found, unreadable, self_pinned
 
 
 def _read_labels_once(path: str, tag: str):
@@ -230,7 +262,8 @@ def rebuild_targets(clone: Path, revision: str, pin: str):
         return None, "the producer has no scripts/affected.py at this ref"
     try:
         result = subprocess.run(["python3", str(selector), "paths"], cwd=str(clone),
-                                input=changed, capture_output=True, text=True, check=True)
+                                input=changed, capture_output=True, text=True, check=True,
+                                timeout=SUBPROCESS_TIMEOUT)
         return json.loads(result.stdout), None
     except Exception as error:
         return None, f"the rebuild selector failed: {str(error)[:140]}"
@@ -325,17 +358,21 @@ def check_images(contracts: dict, facts: dict, cache: Path, channel: str):
         if clone is None:
             continue
         pin = facts["pins"][repo]
-        deployed, unreadable = deployed_images(clone, pin, facts["compose_files"][repo])
+        deployed, unreadable, self_pinned = deployed_images(clone, pin,
+                                                            facts["compose_files"][repo])
         for name, reason in unreadable:
             problems.append(f"{repo}: compose/{name} {reason} - the images it deploys were "
                             f"not checked, so this run's coverage is narrower than it looks")
+        for image, where in sorted(self_pinned):
+            notes.append(f"{repo}: {image} ({where}) takes its tag from the compose rather than "
+                         f"the channel, so it cannot drift - out of scope")
 
         declared = set(contract.get("images") or [])
         for image in sorted(set(deployed) - declared):
             problems.append(f"{repo}: the pinned compose deploys {image} but the contract does not "
                             f"declare it - the producer's own contract gate missed it")
 
-        resolved = 0
+        resolved, out_of_scope = 0, 0
         for image in sorted(deployed):
             labels, outcome, attempts = None, "no_tag", []
             for _, path in mirror_candidates(image, facts["slugs"], repo):
@@ -371,6 +408,12 @@ def check_images(contracts: dict, facts: dict, cache: Path, channel: str):
             owner = next((r for r, s in facts["slugs"].items()
                           if s and s.lower() == source.lower()), None)
             if owner is None:
+                # Genuinely out of scope, so it leaves the denominator as well as the numerator.
+                # Every other unresolved outcome here means "could not tell" and must count
+                # against coverage; this one means "not ours to tell", and counting it would
+                # fail the weekly job forever over an image nobody can do anything about - the
+                # note would say out of scope while the exit status said otherwise.
+                out_of_scope += 1
                 notes.append(f"{repo}: {image} is built by {source or 'an unknown repository'}, "
                              f"which this installer does not pin - out of scope")
                 continue
@@ -397,7 +440,7 @@ def check_images(contracts: dict, facts: dict, cache: Path, channel: str):
             elif verdict == "unknown":
                 notes.append(f"{repo}: {image} not verified - {detail}")
 
-        coverage[(repo, channel)] = (resolved, len(deployed))
+        coverage[(repo, channel)] = (resolved, len(deployed) - out_of_scope)
 
     if out_of_budget:
         # Named, not swallowed. These images were never asked about, so the
@@ -419,10 +462,10 @@ def compare(clone: Path, pin: str, revision: str, image: str, oracle, placements
         except subprocess.CalledProcessError:
             return "unknown", f"revision {revision[:12]} is not reachable in {clone.name}"
 
-    behind = subprocess.run(["git", "-C", str(clone), "merge-base", "--is-ancestor", revision, pin],
-                            capture_output=True).returncode == 0
-    ahead = subprocess.run(["git", "-C", str(clone), "merge-base", "--is-ancestor", pin, revision],
-                           capture_output=True).returncode == 0
+    behind = run(["git", "-C", str(clone), "merge-base", "--is-ancestor", revision, pin],
+                 check=False).returncode == 0
+    ahead = run(["git", "-C", str(clone), "merge-base", "--is-ancestor", pin, revision],
+                check=False).returncode == 0
 
     if behind and ahead:
         return "coherent", "built from the pinned tree"

--- a/scripts/image_coherence.py
+++ b/scripts/image_coherence.py
@@ -23,7 +23,6 @@ and is where the installer actually pulls from, but its unauthenticated budget i
 requests per hour per IP, shared across everything on a runner's egress - so using it here would
 break other jobs rather than this one.
 """
-import concurrent.futures
 import json
 import re
 import subprocess

--- a/scripts/image_coherence.py
+++ b/scripts/image_coherence.py
@@ -206,17 +206,22 @@ def read_labels(path: str, tag: str, sleep=time.sleep, deadline=None):
     `deadline` is a monotonic instant shared by every read in the run. Past it no request is
     made and no retry is waited out: the caller reports what is left as unverified rather than
     being killed part-way through and reporting nothing.
+
+    The deadline is tested at the top of every attempt rather than beside the backoff, so that a
+    sleep which crosses it cannot be followed by one more request. Checking before the wait but
+    not after left exactly that gap - the budget would be spent and a further REGISTRY_TIMEOUT
+    still spendable. The seeded outcome below carries the answer when nothing was attempted at
+    all; once an attempt has been made, its own failure is the more useful thing to report.
     """
-    if deadline is not None and time.monotonic() >= deadline:
-        return None, "budget"
+    labels, outcome = None, "budget"
     for attempt in range(REGISTRY_ATTEMPTS):
+        if deadline is not None and time.monotonic() >= deadline:
+            return labels, outcome
         labels, outcome = _read_labels_once(path, tag)
         if outcome != "transport" or attempt == REGISTRY_ATTEMPTS - 1:
             return labels, outcome
-        if deadline is not None and time.monotonic() >= deadline:
-            return labels, outcome
         sleep(REGISTRY_BACKOFF * (2 ** attempt))
-    return None, "transport"  # unreachable, kept so every path returns a pair
+    return labels, outcome  # unreachable, kept so every path returns a pair
 
 
 def mirror_candidates(image: str, slugs: dict, declaring: str):

--- a/scripts/image_coherence.py
+++ b/scripts/image_coherence.py
@@ -324,9 +324,17 @@ def service_interface(clone: Path, ref: str, compose_name: str, service: str):
 def check_images(contracts: dict, facts: dict, cache: Path, channel: str):
     """Compare what an install pulls against the compose it runs.
 
-    Returns (problems, notes, coverage). Nothing here is a problem unless it is both real and
-    actionable; everything unresolved is a note that names why, and the coverage counts are
-    printed by the caller so a run that verified nothing cannot look like a clean one.
+    Returns (problems, notes, coverage). The invariant that makes the result trustworthy is that
+    every deployed image does exactly one of three things: it reaches a verdict and counts as
+    resolved, it is declared out of scope and leaves the denominator with a note naming it, or it
+    leaves a gap between `resolved` and the total. The caller ASSERTS that gap rather than merely
+    printing it, so an image nobody managed to decide about fails the run - which is why most of
+    the outcomes below are notes and still cannot be ignored.
+
+    Only two things leave the denominator, and both are answers rather than failures to answer:
+    an image the compose pins itself, which cannot drift, and one built by a repository this
+    installer does not pin, which there is no pin to compare against. "Could not tell" is never
+    one of them.
     """
     problems, notes, coverage = [], [], {}
     clones, oracles = {}, {}

--- a/scripts/test_check_contracts.py
+++ b/scripts/test_check_contracts.py
@@ -1,0 +1,136 @@
+"""What a contract run REPORTS, as opposed to what it checks.
+
+Every test here drives main() the way the scheduled job does, with only the network seams
+stubbed. That matters: an adversarial audit of this checker found that the four ways it could
+fail to verify anything all ended in notes, and notes cannot fail a job. A run that reached no
+verdict about any image printed its counts and exited 0. The counts were real; nothing asserted
+them. So these tests assert the exit status, not the text - the exit status is the only part of
+this program the weekly job can act on.
+"""
+
+import io
+import sys
+import unittest
+from contextlib import redirect_stdout, redirect_stderr
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import check_contracts as cc
+import image_coherence as ic
+
+
+class ReportingContract(unittest.TestCase):
+    def setUp(self):
+        self._saved = (cc.fetch, cc.latest_release, cc.release_lag, ic.check_images, sys.argv)
+        # Offline by construction: every seam that would touch a network is answered here.
+        cc.fetch = lambda slug, ref, path: (None, None)   # no upstream contract.yml; snapshot used
+        cc.latest_release = lambda slug: None             # no newer release
+        cc.release_lag = lambda slug, tag: None
+
+    def tearDown(self):
+        (cc.fetch, cc.latest_release, cc.release_lag, ic.check_images, sys.argv) = self._saved
+
+    def run_main(self, *argv, images=None):
+        """Run main() with the image check answering `images`; returns (status, output)."""
+        if images is not None:
+            ic.check_images = images
+        sys.argv = ["check_contracts.py", *argv]
+        out, err = io.StringIO(), io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            status = cc.main()
+        return status, out.getvalue() + err.getvalue()
+
+    # --- the finding that started this: unverified is not verified --------------------------
+    def test_images_that_reached_no_verdict_fail_the_run(self):
+        status, output = self.run_main(
+            "--online", "--fail-on-image-drift",
+            images=lambda *a: ([], ["ovos-docker: not verified - the registry could not be reached"],
+                               {("ovos-docker", "testing"): (0, 28)}))
+        self.assertEqual(status, 1, output)
+        self.assertIn("28 of 28", output)
+        self.assertIn("reached no verdict", output)
+
+    def test_a_fully_verified_run_passes(self):
+        status, output = self.run_main(
+            "--online", "--fail-on-image-drift",
+            images=lambda *a: ([], [], {("ovos-docker", "testing"): (28, 28),
+                                        ("hivemind-docker", "testing"): (2, 2)}))
+        self.assertEqual(status, 0, output)
+        self.assertIn("images checked: ovos-docker@testing 28/28", output)
+
+    def test_a_partially_verified_run_fails_and_says_by_how_much(self):
+        status, output = self.run_main(
+            "--online", "--fail-on-image-drift",
+            images=lambda *a: ([], [], {("ovos-docker", "testing"): (26, 28)}))
+        self.assertEqual(status, 1, output)
+        self.assertIn("2 of 28", output)
+
+    def test_a_repository_with_no_images_checked_at_all_fails(self):
+        """(0, 0) is what a repository that was never reached looks like. It is not success."""
+        status, output = self.run_main(
+            "--online", "--fail-on-image-drift",
+            images=lambda *a: ([], [], {("hivemind-docker", "testing"): (0, 0)}))
+        self.assertEqual(status, 1, output)
+        self.assertIn("not checked", output)
+
+    def test_a_crash_in_the_image_check_is_reported_not_swallowed(self):
+        def boom(*a):
+            raise RuntimeError("buildx exploded")
+        status, output = self.run_main("--online", "--fail-on-image-drift", images=boom)
+        self.assertEqual(status, 1, output)
+        self.assertIn("failed to run", output)
+        self.assertIn("buildx exploded", output)
+
+    # --- the deliberate separation, which must stay deliberate -------------------------------
+    def test_image_drift_is_a_note_until_the_flag_asks_for_a_failure(self):
+        """Drift depends on a registry and on someone else's rebuild schedule, so the pull
+        request check must not go red for it. Only the scheduled job passes the flag."""
+        status, output = self.run_main(
+            "--online",
+            images=lambda *a: (["ovos-docker: an image disagrees with the pinned compose"], [],
+                               {("ovos-docker", "testing"): (0, 28)}))
+        self.assertEqual(status, 0, output)
+        self.assertIn("note:", output)
+
+    def test_the_offline_run_makes_no_claim_about_images(self):
+        def never(*a):
+            raise AssertionError("the offline run must not reach a registry")
+        status, output = self.run_main(images=never)
+        self.assertEqual(status, 0, output)
+        self.assertNotIn("images checked", output)
+
+
+class DependencyBumpRecognition(unittest.TestCase):
+    """Release lag counts commits an install would see; a bot's digest bump is not one.
+
+    The pattern is matched against real subject lines rather than invented ones, because the
+    cost of a miss is asymmetric: a missed bump pages a human every week for nothing, and the
+    alert gets muted, which costs the checks that matter.
+    """
+
+    BUMPS = [
+        "chore(deps): update dependency uv to v0.12.13",
+        "build(deps): bump actions/checkout from 4 to 5",
+        "Update ghcr.io/astral-sh/uv Docker tag to v0.12.13",
+        "Update actions/checkout digest to 08c6903",
+        "chore: update smartgic/ovos-core digest to a1b2c3d",
+    ]
+    REAL = [
+        "fix: gate fann2 behind the lgpl extra",
+        "feat: add the hivemind CLI service",
+        "chore: drop core-buildroot",          # a real removal, not a dependency bump
+        "Update the README with the new channel names",
+    ]
+
+    def test_bot_bumps_are_recognised(self):
+        for line in self.BUMPS:
+            self.assertTrue(cc.DEPENDENCY_BUMP.match(line), line)
+
+    def test_real_changes_are_not_mistaken_for_bumps(self):
+        for line in self.REAL:
+            self.assertFalse(cc.DEPENDENCY_BUMP.match(line), line)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_check_contracts.py
+++ b/scripts/test_check_contracts.py
@@ -101,6 +101,84 @@ class ReportingContract(unittest.TestCase):
         self.assertNotIn("images checked", output)
 
 
+
+class FactsFloor(unittest.TestCase):
+    """A checker holding no facts finds no problems.
+
+    Every fact is pulled out of a file by regular expression. Indenting these defaults under a
+    key - an ordinary Ansible refactor - makes every pattern match nothing, and before this
+    floor existed the run printed "contracts satisfied" having compared nothing at all. A
+    missing file raises, which is loud. A file that no longer matches does not.
+    """
+
+    def facts(self, **overrides):
+        base = {
+            "compose_files": {"ovos-docker": {"docker-compose.yml"},
+                              "hivemind-docker": {"docker-compose.satellite.yml"}},
+            "container_names": {"ovos_cli"},
+            "provided_env": {"TZ"},
+            "pins": {"ovos-docker": "v2.1.0", "hivemind-docker": "v2.1.2"},
+            "channel": "testing",
+            "slugs": {"ovos-docker": "OpenVoiceOS/ovos-docker",
+                      "hivemind-docker": "JarbasHiveMind/hivemind-docker"},
+        }
+        base.update(overrides)
+        return base
+
+    def test_the_real_repository_passes_the_floor(self):
+        """A floor that fires on the repository as it stands is an alarm, not a check."""
+        self.assertEqual(cc.check_facts(cc.installer_facts()), [])
+
+    def test_a_populated_set_of_facts_passes(self):
+        self.assertEqual(cc.check_facts(self.facts()), [])
+
+    def test_no_compose_files_is_a_violation_per_repository(self):
+        problems = cc.check_facts(self.facts(compose_files={"ovos-docker": set(),
+                                                            "hivemind-docker": set()}))
+        self.assertEqual(len([p for p in problems if "no compose file variables" in p]), 2)
+
+    def test_no_container_names_is_a_violation(self):
+        problems = cc.check_facts(self.facts(container_names=set()))
+        self.assertTrue(any("no container names matched" in p for p in problems), problems)
+
+    def test_no_environment_variables_is_a_violation(self):
+        """Empty means every variable upstream requires reads as already supplied."""
+        problems = cc.check_facts(self.facts(provided_env=set()))
+        self.assertTrue(any("would read as supplied" in p for p in problems), problems)
+
+    def test_the_floor_is_wired_into_the_run(self):
+        """Testing the guard is not the same as proving it is called.
+
+        This drives main() with facts whose patterns matched nothing, the state an upstream
+        refactor produces. Before the floor existed it printed "contracts satisfied" and
+        returned 0.
+        """
+        saved = (cc.installer_facts, cc.fetch, cc.latest_release, cc.release_lag, sys.argv)
+        cc.installer_facts = lambda: self.facts(
+            compose_files={"ovos-docker": set(), "hivemind-docker": set()},
+            container_names=set(), provided_env=set())
+        cc.fetch = lambda slug, ref, path: (None, None)
+        cc.latest_release = lambda slug: None
+        cc.release_lag = lambda slug, tag: None
+        sys.argv = ["check_contracts.py"]
+        try:
+            out, err = io.StringIO(), io.StringIO()
+            with redirect_stdout(out), redirect_stderr(err):
+                status = cc.main()
+        finally:
+            (cc.installer_facts, cc.fetch, cc.latest_release, cc.release_lag, sys.argv) = saved
+        output = out.getvalue() + err.getvalue()
+        self.assertEqual(status, 1, output)
+        self.assertIn("nothing about this repository was checked", output)
+        self.assertNotIn("contracts satisfied", output)
+
+    def test_a_missing_pin_or_url_is_a_violation(self):
+        problems = cc.check_facts(self.facts(pins={"ovos-docker": None, "hivemind-docker": None},
+                                             slugs={"ovos-docker": "", "hivemind-docker": ""}))
+        self.assertEqual(len([p for p in problems if "no pin matched" in p]), 2)
+        self.assertEqual(len([p for p in problems if "no repository url matched" in p]), 2)
+
+
 class DependencyBumpRecognition(unittest.TestCase):
     """Release lag counts commits an install would see; a bot's digest bump is not one.
 

--- a/scripts/test_image_coherence.py
+++ b/scripts/test_image_coherence.py
@@ -313,6 +313,20 @@ class CheckImagesReporting(unittest.TestCase):
         self.assertEqual(coverage[("producer", "testing")], (0, 0))
         self.assertTrue(any("out of scope" in n for n in notes), notes)
 
+    def test_an_image_naming_no_source_still_counts_against_coverage(self):
+        """A missing label looks exactly like a third-party image, and is not one.
+
+        If a producer's build stopped emitting org.opencontainers.image.source, every image
+        would read as "built elsewhere" and quietly leave the denominator - a run that verified
+        nothing would report full coverage and pass. Absent is not the same as elsewhere.
+        """
+        ic.read_labels = lambda path, tag, **_: (
+            {"org.opencontainers.image.revision": "0" * 40}, "ok")   # no source label
+        problems, notes, coverage = self.run_check()
+        self.assertEqual(coverage[("producer", "testing")], (0, 1),
+                         "an unattributable image stays in the denominator")
+        self.assertTrue(any("names no source repository" in n for n in notes), notes)
+
     def test_a_compose_file_that_could_not_be_read_is_a_problem(self):
         """Its images are not in `deployed` at all, so coverage alone cannot notice them."""
         real = ic.deployed_images

--- a/scripts/test_image_coherence.py
+++ b/scripts/test_image_coherence.py
@@ -177,15 +177,152 @@ class UnreleasedImpact(unittest.TestCase):
         affects, detail = ic.unreleased_impact(self.repo, "v1.0.0", "dev", {"docker-compose.yml"})
         self.assertFalse(affects, detail)
 
-    def test_a_change_that_rebuilds_an_image_does_warrant_one(self):
+    def test_a_rebuild_the_channel_tag_already_delivers_does_not_warrant_one(self):
+        """The asymmetry the whole checker rests on.
+
+        Compose files are read from the clone at the PINNED tag, so a compose change reaches
+        nobody until a release. Images are pulled by a MOVING channel tag, so a Dockerfile
+        change reaches every install on the next publish with no release at all. Calling that
+        a release lag would page a human weekly for work already delivered.
+        """
+        commit(self.repo, "app/Dockerfile", "FROM scratch\nRUN true\n", "image change")
+        affects, detail = ic.unreleased_impact(self.repo, "v1.0.0", "dev", {"docker-compose.yml"})
+        self.assertFalse(affects, detail)
+        self.assertIn("channel tag", detail)
+
+    def test_a_compose_change_is_still_reported_when_it_also_rebuilds_images(self):
+        """The image rebuild must not swallow the compose change riding along with it."""
+        commit(self.repo, "compose/docker-compose.yml", "services: {x: {}}\n", "compose change")
         commit(self.repo, "app/Dockerfile", "FROM scratch\nRUN true\n", "image change")
         affects, detail = ic.unreleased_impact(self.repo, "v1.0.0", "dev", {"docker-compose.yml"})
         self.assertTrue(affects, detail)
-        self.assertIn("rebuilds", detail)
+        self.assertIn("docker-compose.yml", detail)
+        self.assertIn("also rebuilds", detail)
 
     def test_nothing_unreleased_is_not_an_impact(self):
         affects, detail = ic.unreleased_impact(self.repo, "v1.0.0", "dev", {"docker-compose.yml"})
         self.assertFalse(affects, detail)
+
+
+
+class CheckImagesReporting(unittest.TestCase):
+    """What check_images turns into output.
+
+    None of this was covered before: every guard lived in a branch no test drove, so the audit
+    found four ways a run could verify nothing and still report success. These assert the
+    reporting contract itself - an unresolved image must be visible in the coverage count AND
+    reachable by --fail-on-image-drift, never a note that cannot fail anything.
+    """
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self._tmp.name)
+        self.repo = self.root / "producer"
+        self.repo.mkdir()
+        git(self.repo, "init", "-q")
+        commit(self.repo, "scripts/affected.py", SELECTOR, "selector")
+        commit(self.repo, "compose/docker-compose.yml",
+               "services:\n  app:\n    image: smartgic/app:${VERSION}\n", "compose")
+        git(self.repo, "tag", "v1.0.0")
+
+        self.facts = {
+            "compose_files": {"producer": {"docker-compose.yml"}},
+            "pins": {"producer": "v1.0.0"},
+            "slugs": {"producer": "Org/producer"},
+        }
+        self.contracts = {"producer": {"images": ["docker.io/smartgic/app"]}}
+        self._real = (ic.pin_clone, ic.target_images, ic.read_labels)
+        ic.pin_clone = lambda slug, ref, cache: self.repo
+        ic.target_images = lambda clone: {"docker.io/smartgic/app": "app"}
+
+    def tearDown(self):
+        ic.pin_clone, ic.target_images, ic.read_labels = self._real
+        self._tmp.cleanup()
+
+    def run_check(self):
+        return ic.check_images(self.contracts, self.facts, self.root / "cache", "testing")
+
+    def test_an_unreachable_registry_is_not_counted_as_verified(self):
+        ic.read_labels = lambda path, tag: (None, "transport")
+        problems, notes, coverage = self.run_check()
+        self.assertEqual(coverage[("producer", "testing")], (0, 1))
+        self.assertTrue(any("could not be reached" in n for n in notes), notes)
+
+    def test_a_missing_channel_tag_is_a_problem_not_a_note(self):
+        """An install pulling a tag that does not exist fails; that is a finding."""
+        ic.read_labels = lambda path, tag: (None, "no_tag")
+        problems, notes, coverage = self.run_check()
+        self.assertTrue(any("no :testing tag is published" in p for p in problems), problems)
+
+    def test_an_undecided_verdict_does_not_count_toward_coverage(self):
+        ic.target_images = lambda clone: None          # no bake graph -> cannot attribute
+        ic.read_labels = lambda path, tag: (
+            {"org.opencontainers.image.revision": "0" * 40,
+             "org.opencontainers.image.source": "https://github.com/Org/producer"}, "ok")
+        problems, notes, coverage = self.run_check()
+        self.assertEqual(coverage[("producer", "testing")], (0, 1))
+
+    def test_a_repository_that_cannot_be_cloned_still_gets_a_coverage_entry(self):
+        def boom(slug, ref, cache):
+            raise RuntimeError("network down")
+        ic.pin_clone = boom
+        problems, notes, coverage = self.run_check()
+        self.assertIn(("producer", "testing"), coverage)
+        self.assertTrue(any("could not clone" in p for p in problems), problems)
+
+    def test_an_image_the_contract_does_not_declare_is_a_problem(self):
+        self.contracts = {"producer": {"images": []}}
+        ic.read_labels = lambda path, tag: (None, "transport")
+        problems, notes, coverage = self.run_check()
+        self.assertTrue(any("does not declare it" in p for p in problems), problems)
+
+    def test_the_most_severe_mirror_outcome_wins(self):
+        """Candidates are tried in order; the last one's outcome must not decide."""
+        seen = []
+
+        def by_candidate(path, tag):
+            seen.append(path)
+            return (None, "transport" if len(seen) == 1 else "no_tag")
+
+        self.facts["slugs"]["other"] = "Org/other"
+        self.facts["compose_files"]["other"] = set()
+        self.facts["pins"]["other"] = "v1.0.0"
+        self.contracts["other"] = {"images": []}
+        ic.read_labels = by_candidate
+        problems, notes, coverage = self.run_check()
+        self.assertTrue(any("could not be reached" in n for n in notes), notes)
+
+
+class AheadDirection(unittest.TestCase):
+    """Ahead of the pin, with the service definition unreadable, is not agreement."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.repo = Path(self._tmp.name) / "producer"
+        self.repo.mkdir()
+        git(self.repo, "init", "-q")
+        commit(self.repo, "scripts/affected.py", SELECTOR, "selector")
+        self.pin = commit(self.repo, "app/Dockerfile", "FROM scratch\n", "pin")
+        self.newer = commit(self.repo, "app/Dockerfile", "FROM scratch\nRUN true\n", "newer")
+        self.other = Path(self._tmp.name) / "other"
+        self.other.mkdir()
+        git(self.other, "init", "-q")
+        commit(self.other, "README.md", "x\n", "other repo")
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_unreadable_service_definition_is_unknown_not_coherent(self):
+        verdict, detail = ic.compare(self.repo, self.pin, self.newer, "img", {"img": "app"},
+                                     {"docker-compose.yml": "app"}, self.repo, self.pin)
+        self.assertEqual(verdict, "unknown", detail)
+
+    def test_a_cross_repository_image_is_not_compared_against_the_wrong_tree(self):
+        """The compose file belongs to the deployer, not the builder."""
+        verdict, detail = ic.compare(self.repo, self.pin, self.newer, "img", {"img": "app"},
+                                     {"docker-compose.hivemind.yml": "cli"}, self.other, "HEAD")
+        self.assertEqual(verdict, "unknown", detail)
+        self.assertIn("another repository", detail)
 
 
 if __name__ == "__main__":

--- a/scripts/test_image_coherence.py
+++ b/scripts/test_image_coherence.py
@@ -325,5 +325,61 @@ class AheadDirection(unittest.TestCase):
         self.assertIn("another repository", detail)
 
 
+
+class RegistryRetry(unittest.TestCase):
+    """Telling a hiccup apart from an outage.
+
+    Making an unreachable registry a failure is only safe if a blip is not one. A run reads
+    around thirty images at three or four requests each, so over enough weeks a single transient
+    failure is close to certain - and a job that goes red for reasons nobody can act on gets
+    muted, which costs every check it was carrying.
+    """
+
+    def setUp(self):
+        self._once = ic._read_labels_once
+        self.slept = []
+
+    def tearDown(self):
+        ic._read_labels_once = self._once
+
+    def stub(self, *outcomes):
+        """Answer with each outcome in turn, then repeat the last."""
+        calls = []
+
+        def once(path, tag):
+            calls.append(path)
+            index = min(len(calls) - 1, len(outcomes) - 1)
+            return outcomes[index]
+
+        ic._read_labels_once = once
+        return calls
+
+    def test_a_transient_failure_is_retried_and_recovers(self):
+        calls = self.stub((None, "transport"), ({"a": "b"}, "ok"))
+        labels, outcome = ic.read_labels("org/img", "testing", sleep=self.slept.append)
+        self.assertEqual((labels, outcome), ({"a": "b"}, "ok"))
+        self.assertEqual(len(calls), 2)
+
+    def test_a_persistent_outage_still_fails(self):
+        calls = self.stub((None, "transport"))
+        labels, outcome = ic.read_labels("org/img", "testing", sleep=self.slept.append)
+        self.assertEqual(outcome, "transport")
+        self.assertEqual(len(calls), ic.REGISTRY_ATTEMPTS)
+
+    def test_a_definitive_answer_is_not_retried(self):
+        """404 and 401 are answers. Asking again only spends requests against a rate limit."""
+        for decisive in ("no_tag", "denied", "ok"):
+            calls = self.stub((None, decisive))
+            ic.read_labels("org/img", "testing", sleep=self.slept.append)
+            self.assertEqual(len(calls), 1, decisive)
+
+    def test_the_backoff_grows_and_is_bounded(self):
+        self.stub((None, "transport"))
+        ic.read_labels("org/img", "testing", sleep=self.slept.append)
+        self.assertEqual(len(self.slept), ic.REGISTRY_ATTEMPTS - 1)  # no sleep after the last try
+        self.assertEqual(self.slept, sorted(self.slept))
+        self.assertLess(sum(self.slept), 60)  # a stuck registry must not stall the whole run
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/scripts/test_image_coherence.py
+++ b/scripts/test_image_coherence.py
@@ -222,8 +222,8 @@ class CheckImagesReporting(unittest.TestCase):
         self.repo.mkdir()
         git(self.repo, "init", "-q")
         commit(self.repo, "scripts/affected.py", SELECTOR, "selector")
-        commit(self.repo, "compose/docker-compose.yml",
-               "services:\n  app:\n    image: smartgic/app:${VERSION}\n", "compose")
+        self.pin = commit(self.repo, "compose/docker-compose.yml",
+                          "services:\n  app:\n    image: smartgic/app:${VERSION}\n", "compose")
         git(self.repo, "tag", "v1.0.0")
 
         self.facts = {
@@ -326,6 +326,50 @@ class CheckImagesReporting(unittest.TestCase):
         self.assertEqual(coverage[("producer", "testing")], (0, 1),
                          "an unattributable image stays in the denominator")
         self.assertTrue(any("names no source repository" in n for n in notes), notes)
+
+    def test_every_outcome_either_resolves_or_is_visible(self):
+        """The invariant, swept across every outcome rather than one case at a time.
+
+        A deployed image must do exactly one of three things: reach a verdict and count as
+        resolved, be declared out of scope and leave the denominator with a note naming it, or
+        leave a gap between resolved and the total. The third is what the caller asserts, so a
+        new outcome added later cannot quietly become a fourth kind that counts as verified
+        without deciding anything.
+        """
+        OUTCOMES = {
+            "transport": "gap", "denied": "gap", "no_tag": "gap", "budget": "gap",
+            "no_revision": "gap", "no_source": "gap", "elsewhere": "out_of_scope",
+            "ours": "resolved",
+        }
+        for outcome, expected in OUTCOMES.items():
+            with self.subTest(outcome=outcome):
+                if outcome == "no_revision":
+                    labels = {"org.opencontainers.image.source": "https://github.com/Org/producer"}
+                    ic.read_labels = lambda p, t, **_: (dict(labels), "ok")
+                elif outcome == "no_source":
+                    ic.read_labels = lambda p, t, **_: (
+                        {"org.opencontainers.image.revision": "0" * 40}, "ok")
+                elif outcome == "elsewhere":
+                    ic.read_labels = lambda p, t, **_: (
+                        {"org.opencontainers.image.revision": "0" * 40,
+                         "org.opencontainers.image.source": "https://github.com/Other/repo"}, "ok")
+                elif outcome == "ours":
+                    ic.read_labels = lambda p, t, **_: (
+                        {"org.opencontainers.image.revision": self.pin,
+                         "org.opencontainers.image.source": "https://github.com/Org/producer"}, "ok")
+                else:
+                    ic.read_labels = (lambda o: lambda p, t, **_: (None, o))(outcome)
+
+                problems, notes, coverage = self.run_check()
+                resolved, total = coverage[("producer", "testing")]
+                if expected == "resolved":
+                    self.assertEqual((resolved, total), (1, 1))
+                elif expected == "out_of_scope":
+                    self.assertEqual((resolved, total), (0, 0), "left the denominator")
+                    self.assertTrue(any("out of scope" in n for n in notes), notes)
+                else:
+                    self.assertEqual((resolved, total), (0, 1),
+                                     f"{outcome} must leave a visible gap")
 
     def test_a_compose_file_that_could_not_be_read_is_a_problem(self):
         """Its images are not in `deployed` at all, so coverage alone cannot notice them."""

--- a/scripts/test_image_coherence.py
+++ b/scripts/test_image_coherence.py
@@ -286,12 +286,39 @@ class CheckImagesReporting(unittest.TestCase):
         self.assertEqual(total, 1, "the skipped image still counts against what was claimed")
         self.assertTrue(any("budget" in n for n in notes), notes)
 
+    def test_a_self_pinned_image_is_reported_as_out_of_scope(self):
+        """Excluding it from the check is right; excluding it from the report is not."""
+        real = ic.deployed_images
+        try:
+            ic.deployed_images = lambda clone, ref, names: (
+                {}, [], [("redis:7-alpine", "docker-compose.yml:cache")])
+            problems, notes, coverage = self.run_check()
+        finally:
+            ic.deployed_images = real
+        self.assertTrue(any("out of scope" in n and "redis:7-alpine" in n for n in notes), notes)
+        self.assertEqual(problems, [], "a pinned image is not a defect")
+
+    def test_an_image_built_elsewhere_leaves_the_denominator_too(self):
+        """"Could not tell" and "not ours to tell" are different, and only one is a defect.
+
+        Every other unresolved outcome counts against coverage, which is what turns it into a
+        violation. This one would fail the weekly job forever over an image nobody can act on,
+        while the note beside it said "out of scope" - the report and the exit status
+        disagreeing about the same image.
+        """
+        ic.read_labels = lambda path, tag, **_: (
+            {"org.opencontainers.image.revision": "0" * 40,
+             "org.opencontainers.image.source": "https://github.com/SomeoneElse/their-repo"}, "ok")
+        problems, notes, coverage = self.run_check()
+        self.assertEqual(coverage[("producer", "testing")], (0, 0))
+        self.assertTrue(any("out of scope" in n for n in notes), notes)
+
     def test_a_compose_file_that_could_not_be_read_is_a_problem(self):
         """Its images are not in `deployed` at all, so coverage alone cannot notice them."""
         real = ic.deployed_images
         try:
             ic.deployed_images = lambda clone, ref, names: (
-                {}, [("docker-compose.yml", "is not valid YAML (mapping values not allowed)")])
+                {}, [("docker-compose.yml", "is not valid YAML (mapping values not allowed)")], [])
             problems, notes, coverage = self.run_check()
         finally:
             ic.deployed_images = real
@@ -408,6 +435,57 @@ class RegistryRetry(unittest.TestCase):
         self.assertLess(sum(self.slept), 60)  # a stuck registry must not stall the whole run
 
 
+
+class HangingIsFailing(unittest.TestCase):
+    """A command that never returns must reach the same handler as one that fails.
+
+    Every git, gh and docker call this program makes talks to a network or a daemon, and none of
+    them carried a ceiling: a blackholed fetch simply never returned. The only bound was the
+    job's own timeout, and a job killed by that reports nothing at all - including the images it
+    had already resolved. That is the same outcome the registry budget exists to avoid.
+    """
+
+    def test_a_timeout_is_raised_as_a_failed_command(self):
+        """Callers catch CalledProcessError. None of them catches TimeoutExpired."""
+        with self.assertRaises(subprocess.CalledProcessError) as caught:
+            ic.run(["sleep", "5"], timeout=0.2)
+        self.assertEqual(caught.exception.returncode, 124)
+        self.assertIn("no answer after", caught.exception.stderr)
+
+    def test_a_hung_command_degrades_one_answer_rather_than_the_run(self):
+        """deployed_images already treats a failed git show as a file it could not read."""
+        real = ic.run
+        try:
+            ic.run = lambda *a, **k: real(["sleep", "5"], timeout=0.2)
+            found, unreadable, self_pinned = ic.deployed_images(Path(tempfile.gettempdir()), "HEAD",
+                                                  ["docker-compose.yml"])
+        finally:
+            ic.run = real
+        self.assertEqual(found, {})
+        self.assertEqual([name for name, _ in unreadable], ["docker-compose.yml"])
+
+    def test_a_caller_that_asks_for_no_ceiling_still_gets_one(self):
+        """Every call site relies on the default; none of them passes a timeout."""
+        seen = {}
+        real = subprocess.run
+
+        def capture(*args, **kwargs):
+            seen.update(kwargs)
+            return real(["true"], capture_output=True, text=True)
+
+        subprocess.run = capture
+        try:
+            ic.run(["git", "status"])
+        finally:
+            subprocess.run = real
+        self.assertIsNotNone(seen.get("timeout"), "run() passed no ceiling to subprocess")
+        self.assertEqual(seen["timeout"], ic.SUBPROCESS_TIMEOUT)
+
+    def test_the_default_ceiling_is_bounded_and_generous(self):
+        self.assertLessEqual(ic.SUBPROCESS_TIMEOUT, 600)
+        self.assertGreaterEqual(ic.SUBPROCESS_TIMEOUT, 60)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)
 
@@ -419,13 +497,39 @@ class CoverageScopeIsNotSilentlyNarrowed(unittest.TestCase):
         real_run = ic.run
         try:
             ic.run = lambda cmd, *a, **k: type("R", (), {"stdout": "services: [broken: : :"})()
-            found, unreadable = ic.deployed_images(
+            found, unreadable, self_pinned = ic.deployed_images(
                 Path(tempfile.gettempdir()), "HEAD", ["docker-compose.yml"])
         finally:
             ic.run = real_run
         self.assertEqual(found, {}, "nothing is parsed out of a broken file")
         self.assertEqual([name for name, _ in unreadable], ["docker-compose.yml"])
         self.assertIn("not valid YAML", unreadable[0][1])
+
+
+    def test_an_image_the_compose_pins_itself_is_out_of_scope_and_named(self):
+        """The check asks what :<channel> holds. A self-pinned image has no such question.
+
+        Asking anyway looks the image up under a producer mirror that has no such tag and
+        reports that an install pulling it would fail - untrue, and unfixable by anyone, which
+        is how a weekly alarm gets muted. It is named rather than dropped, because out of scope
+        is a defensible answer and out of sight is not.
+        """
+        real = ic.run
+        try:
+            ic.run = lambda *a, **k: type("R", (), {"stdout": (
+                "services:\n"
+                "  app:\n    image: smartgic/app:${VERSION}\n"
+                "  cache:\n    image: redis:7-alpine\n"
+                "  db:\n    image: postgres\n")})()
+            found, unreadable, self_pinned = ic.deployed_images(
+                Path(tempfile.gettempdir()), "HEAD", ["docker-compose.yml"])
+        finally:
+            ic.run = real
+        self.assertEqual(sorted(found), ["docker.io/smartgic/app"])
+        self.assertEqual(unreadable, [])
+        # both the fixed tag and the absent one: the compose decides each, not the channel
+        self.assertEqual(sorted(image for image, _ in self_pinned), ["postgres", "redis:7-alpine"])
+        self.assertTrue(all(where.startswith("docker-compose.yml:") for _, where in self_pinned))
 
     def test_a_compose_missing_from_the_pinned_tree_is_named(self):
         real_run = ic.run
@@ -435,7 +539,7 @@ class CoverageScopeIsNotSilentlyNarrowed(unittest.TestCase):
 
         try:
             ic.run = boom
-            found, unreadable = ic.deployed_images(
+            found, unreadable, self_pinned = ic.deployed_images(
                 Path(tempfile.gettempdir()), "HEAD", ["docker-compose.yml"])
         finally:
             ic.run = real_run
@@ -446,8 +550,8 @@ class CoverageScopeIsNotSilentlyNarrowed(unittest.TestCase):
         real_run = ic.run
         try:
             ic.run = lambda cmd, *a, **k: type(
-                "R", (), {"stdout": "services:\n  app:\n    image: smartgic/app:1\n"})()
-            found, unreadable = ic.deployed_images(
+                "R", (), {"stdout": "services:\n  app:\n    image: smartgic/app:${VERSION}\n"})()
+            found, unreadable, self_pinned = ic.deployed_images(
                 Path(tempfile.gettempdir()), "HEAD", ["docker-compose.yml"])
         finally:
             ic.run = real_run

--- a/scripts/test_image_coherence.py
+++ b/scripts/test_image_coherence.py
@@ -645,6 +645,26 @@ class RegistryReadsAreBounded(unittest.TestCase):
         self.assertEqual(outcome, "transport")
         self.assertEqual(len(self.calls), ic.REGISTRY_ATTEMPTS)
 
+    def test_a_backoff_that_crosses_the_deadline_makes_no_further_request(self):
+        """Checking beside the wait but not after it left one more request spendable.
+
+        Deterministic rather than timing-dependent: the stub sleep moves a fake clock past the
+        deadline, so the retry is attempted at exactly the instant the budget runs out.
+        """
+        now = [1000.0]
+        real_monotonic = ic.time.monotonic
+        ic.time.monotonic = lambda: now[0]
+        try:
+            labels, outcome = ic.read_labels(
+                "ghcr.io/x/y", "alpha",
+                sleep=lambda seconds: now.__setitem__(0, now[0] + 3600),  # overshoot the budget
+                deadline=now[0] + 1)
+        finally:
+            ic.time.monotonic = real_monotonic
+        self.assertEqual(len(self.calls), 1, "the retry must not start after the budget is gone")
+        self.assertEqual(outcome, "transport",
+                         "an attempt was made and failed, which is the more useful answer")
+
     def test_without_a_deadline_behaviour_is_unchanged(self):
         labels, outcome = ic.read_labels("ghcr.io/x/y", "alpha", sleep=lambda s: None)
         self.assertEqual(len(self.calls), ic.REGISTRY_ATTEMPTS)

--- a/scripts/test_image_coherence.py
+++ b/scripts/test_image_coherence.py
@@ -11,6 +11,7 @@ Every guard here is asserted in both directions. A check that only ever passes p
 import subprocess
 import sys
 import tempfile
+import time
 import unittest
 from pathlib import Path
 
@@ -243,20 +244,20 @@ class CheckImagesReporting(unittest.TestCase):
         return ic.check_images(self.contracts, self.facts, self.root / "cache", "testing")
 
     def test_an_unreachable_registry_is_not_counted_as_verified(self):
-        ic.read_labels = lambda path, tag: (None, "transport")
+        ic.read_labels = lambda path, tag, **_: (None, "transport")
         problems, notes, coverage = self.run_check()
         self.assertEqual(coverage[("producer", "testing")], (0, 1))
         self.assertTrue(any("could not be reached" in n for n in notes), notes)
 
     def test_a_missing_channel_tag_is_a_problem_not_a_note(self):
         """An install pulling a tag that does not exist fails; that is a finding."""
-        ic.read_labels = lambda path, tag: (None, "no_tag")
+        ic.read_labels = lambda path, tag, **_: (None, "no_tag")
         problems, notes, coverage = self.run_check()
         self.assertTrue(any("no :testing tag is published" in p for p in problems), problems)
 
     def test_an_undecided_verdict_does_not_count_toward_coverage(self):
         ic.target_images = lambda clone: None          # no bake graph -> cannot attribute
-        ic.read_labels = lambda path, tag: (
+        ic.read_labels = lambda path, tag, **_: (
             {"org.opencontainers.image.revision": "0" * 40,
              "org.opencontainers.image.source": "https://github.com/Org/producer"}, "ok")
         problems, notes, coverage = self.run_check()
@@ -270,9 +271,35 @@ class CheckImagesReporting(unittest.TestCase):
         self.assertIn(("producer", "testing"), coverage)
         self.assertTrue(any("could not clone" in p for p in problems), problems)
 
+
+    def test_an_image_skipped_for_budget_is_missing_from_coverage(self):
+        """The wiring, not the unit.
+
+        A budget-skipped image is never asked about, so it must stay OUT of the resolved count
+        while remaining IN the denominator - that gap is what check_contracts turns into a
+        violation. A note saying "12 images not verified" cannot fail a job on its own.
+        """
+        ic.read_labels = lambda path, tag, **_: (None, "budget")
+        problems, notes, coverage = self.run_check()
+        resolved, total = coverage[("producer", "testing")]
+        self.assertEqual(resolved, 0)
+        self.assertEqual(total, 1, "the skipped image still counts against what was claimed")
+        self.assertTrue(any("budget" in n for n in notes), notes)
+
+    def test_a_compose_file_that_could_not_be_read_is_a_problem(self):
+        """Its images are not in `deployed` at all, so coverage alone cannot notice them."""
+        real = ic.deployed_images
+        try:
+            ic.deployed_images = lambda clone, ref, names: (
+                {}, [("docker-compose.yml", "is not valid YAML (mapping values not allowed)")])
+            problems, notes, coverage = self.run_check()
+        finally:
+            ic.deployed_images = real
+        self.assertTrue(any("coverage is narrower than it looks" in p for p in problems), problems)
+
     def test_an_image_the_contract_does_not_declare_is_a_problem(self):
         self.contracts = {"producer": {"images": []}}
-        ic.read_labels = lambda path, tag: (None, "transport")
+        ic.read_labels = lambda path, tag, **_: (None, "transport")
         problems, notes, coverage = self.run_check()
         self.assertTrue(any("does not declare it" in p for p in problems), problems)
 
@@ -280,7 +307,7 @@ class CheckImagesReporting(unittest.TestCase):
         """Candidates are tried in order; the last one's outcome must not decide."""
         seen = []
 
-        def by_candidate(path, tag):
+        def by_candidate(path, tag, **_):
             seen.append(path)
             return (None, "transport" if len(seen) == 1 else "no_tag")
 
@@ -383,3 +410,79 @@ class RegistryRetry(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)
+
+
+class CoverageScopeIsNotSilentlyNarrowed(unittest.TestCase):
+    """A compose file the run could not read must not shrink what it claims to cover."""
+
+    def test_an_unparseable_compose_is_named_rather_than_skipped(self):
+        real_run = ic.run
+        try:
+            ic.run = lambda cmd, *a, **k: type("R", (), {"stdout": "services: [broken: : :"})()
+            found, unreadable = ic.deployed_images(
+                Path(tempfile.gettempdir()), "HEAD", ["docker-compose.yml"])
+        finally:
+            ic.run = real_run
+        self.assertEqual(found, {}, "nothing is parsed out of a broken file")
+        self.assertEqual([name for name, _ in unreadable], ["docker-compose.yml"])
+        self.assertIn("not valid YAML", unreadable[0][1])
+
+    def test_a_compose_missing_from_the_pinned_tree_is_named(self):
+        real_run = ic.run
+
+        def boom(cmd, *a, **k):
+            raise subprocess.CalledProcessError(128, cmd)
+
+        try:
+            ic.run = boom
+            found, unreadable = ic.deployed_images(
+                Path(tempfile.gettempdir()), "HEAD", ["docker-compose.yml"])
+        finally:
+            ic.run = real_run
+        self.assertEqual(found, {})
+        self.assertIn("not in the pinned tree", unreadable[0][1])
+
+    def test_a_readable_compose_reports_nothing_unreadable(self):
+        real_run = ic.run
+        try:
+            ic.run = lambda cmd, *a, **k: type(
+                "R", (), {"stdout": "services:\n  app:\n    image: smartgic/app:1\n"})()
+            found, unreadable = ic.deployed_images(
+                Path(tempfile.gettempdir()), "HEAD", ["docker-compose.yml"])
+        finally:
+            ic.run = real_run
+        self.assertEqual(unreadable, [])
+        self.assertTrue(found)
+
+
+class RegistryReadsAreBounded(unittest.TestCase):
+    """Every registry read in a run shares one wall-clock ceiling.
+
+    Each candidate can cost REGISTRY_TIMEOUT * REGISTRY_ATTEMPTS plus backoff, and a run
+    reads up to two candidates per deployed image, so a wide outage scales past the job's
+    own timeout. Being killed mid-check reports nothing at all, including what resolved.
+    """
+
+    def setUp(self):
+        self._real_once = ic._read_labels_once
+        self.calls = []
+        ic._read_labels_once = lambda path, tag: (self.calls.append(path), (None, "transport"))[1]
+
+    def tearDown(self):
+        ic._read_labels_once = self._real_once
+
+    def test_no_request_is_made_once_the_budget_is_spent(self):
+        labels, outcome = ic.read_labels(
+            "ghcr.io/x/y", "alpha", sleep=lambda s: None, deadline=time.monotonic() - 1)
+        self.assertEqual(outcome, "budget")
+        self.assertEqual(self.calls, [], "a spent budget makes no request at all")
+
+    def test_a_live_budget_still_retries(self):
+        labels, outcome = ic.read_labels(
+            "ghcr.io/x/y", "alpha", sleep=lambda s: None, deadline=time.monotonic() + 600)
+        self.assertEqual(outcome, "transport")
+        self.assertEqual(len(self.calls), ic.REGISTRY_ATTEMPTS)
+
+    def test_without_a_deadline_behaviour_is_unchanged(self):
+        labels, outcome = ic.read_labels("ghcr.io/x/y", "alpha", sleep=lambda s: None)
+        self.assertEqual(len(self.calls), ic.REGISTRY_ATTEMPTS)

--- a/tests/bats/code_quality.bats
+++ b/tests/bats/code_quality.bats
@@ -3831,26 +3831,24 @@ function teardown() {
     assert_output ""
 }
 
-@test "image_coherence_decision_logic_is_tested_offline" {
-    # The image check itself needs a registry, so its decisions are exercised against a
-    # throwaway git repository instead: which side of the pin an image sits on, whether the
+@test "contract_checker_decision_logic_and_reporting_are_tested_offline" {
+    # Two suites, both offline, discovered by pattern rather than by name so that adding a
+    # third does not silently go unrun - which is what happened to the reporting suite, whose
+    # tests existed and were never executed by CI.
+    #
+    # image_coherence: the check needs a registry, so its decisions are exercised against a
+    # throwaway git repository instead - which side of the pin an image sits on, whether the
     # producer's own selector says it would be rebuilt, and that an image behind the pin by a
     # harmless commit stays quiet. That last one is the whole reason the check is not simply
-    # "revision >= pinned ref" - images are rebuilt when constraints move, with no commit here
+    # "revision >= pinned ref": images are rebuilt when constraints move, with no commit here
     # at all, so being behind is the normal state rather than a defect.
-    run python3 -m unittest discover -s scripts -p "test_image_coherence.py" -q
-    assert_success
-}
-
-@test "online_checks_report_how_many_images_they_actually_verified" {
-    # A run that resolved nothing must not read like a clean one. The coverage line is printed
-    # unconditionally, and every unresolved image becomes a note naming why.
-    local script="scripts/check_contracts.py"
-
-    run grep -q "images checked:" "$script"
-    assert_success
-
-    # the outcomes stay distinct: a registry that could not be reached is not "no such tag"
-    run grep -qE "no_tag|denied|transport" scripts/image_coherence.py
+    #
+    # check_contracts: what a run REPORTS. An audit found four ways it could establish nothing
+    # about any image and still exit 0, all of them ending in a note, and a note cannot fail a
+    # job. These drive main() and assert the exit status, because the exit status is the only
+    # part of this program the scheduled job can act on. Asserting it here rather than grepping
+    # the source for "images checked:" is the point - the string was present the whole time the
+    # behaviour was wrong.
+    run python3 -m unittest discover -s scripts -p "test_*.py" -q
     assert_success
 }


### PR DESCRIPTION
An adversarial audit of the cross-repository contract checker found that a scheduled run could establish nothing about any image and still exit 0.

Four separate paths — an unreachable registry, a channel tag that is not published, an absent bake graph, a clone that failed — all ended in a note, and a note cannot fail a job. The run printed honest coverage counts that nothing asserted, said `contracts satisfied`, and went green. As an unattended weekly alarm that is the worst possible failure: it is indistinguishable from working.

Review then found two more instances of the same class, and sweeping for the pattern found four more.

## The invariant

Every deployed image does exactly one of three things:

- reaches a verdict and counts as **resolved**;
- is declared **out of scope** and leaves the denominator, with a note naming it;
- leaves a **gap** between `resolved` and the total.

The caller *asserts* that gap rather than printing it, so an image nobody managed to decide about fails the run. Only two things leave the denominator, and both are answers rather than failures to answer: an image the compose pins itself, which cannot drift, and one built by a repository this installer does not pin, which there is no pin to compare against. **"Could not tell" is never one of them.**

## What changed

**Unverified means unverified.** The four original paths leave an image unresolved, and unresolved is a violation under `--fail-on-image-drift`. Coverage is seeded before every early exit, so a repository that was never reached shows `0/0 (not checked)` rather than vanishing; and only a decisive verdict increments it, because reading an image's labels is not deciding about it.

**Two verdicts pointed the wrong way.** An image ahead of the pin whose service definition could not be read was reported *coherent*. That definition was also read from the **builder's** tree rather than the **deployer's** — ovos-docker's compose deploys `hivemind-cli` and hivemind-docker has no such file — so the lookup came back empty and read as agreement for every cross-repository image.

**Release lag erred the other way** and would have paged weekly for work already delivered. Compose files are read from the clone at the **pinned tag**, so a compose change reaches nobody until a release; images are pulled by a **moving channel tag**, so a change that only rebuilds an image reaches every install on the next publish. Only the former is a lag.

**Coverage could silently shrink** (from review). `deployed_images` dropped a compose file it could not parse and returned what was left, so the denominator shrank with it — the run could report complete coverage having never looked at the malformed file.

**The retry needed a ceiling** (from review). Making an unreachable registry a failure is only safe if a blip is not one, so transport failures retry — but two candidates across thirty images then runs past the job's own timeout, and a job killed by `timeout-minutes` reports *nothing*, including what it had already resolved. That is strictly worse than the bug. One monotonic deadline is now shared by every read.

**Nothing else had a ceiling either.** No `git`, `gh` or `docker` call carried a `timeout`; a blackholed fetch simply never returns. A timeout now raises `CalledProcessError`, so hanging reaches the same handler as failing — every caller already handles a command that failed, none could handle one that never returns.

**Two questions the checker could not answer** were being asked anyway. An image the compose pins itself would be looked up under a producer mirror with no such tag and reported as "an install pulling it would fail" — untrue and unfixable, which is how an alarm gets muted. And an image built by an unpinned repository said "out of scope" in a note while still counting against coverage, so it would have failed the job forever.

**The facts themselves are now asserted.** Every fact is pulled out of a file by regular expression; indenting the containers-role defaults under a key makes every pattern match nothing, and the offline run — the one gating every pull request — printed `contracts satisfied` having compared nothing at all.

## Verification

62 tests (16 pre-existing), 576 bats, ansible-lint `production` clean, ruff clean.

Every fix is mutation-tested: reverting it individually turns the suite red. Two mutations survived a first pass and both were the same mistake — a guard unit-tested but never proven to be *called*; the tests that close them drive `main()` and `check_images`. The invariant above is swept across all eight outcomes rather than checked case by case, so a ninth cannot quietly become a kind that counts as verified without deciding anything.

A live `--online --fail-on-stale --fail-on-image-drift` run reports `ovos-docker@testing 28/28`, `hivemind-docker@testing 2/2`, exit 0, and classifies [ovos-docker#179](https://github.com/OpenVoiceOS/ovos-docker/pull/179) correctly as *"only paths no install consumes; the 31 image(s) they rebuild reach installs on the channel tag"*. Under the old rule that merge alone would have turned the weekly job red.

It also caught a real failure unprompted: while the GitHub API was rate-limited it reported *"could not check release freshness … the pin and the release lag were not verified"* and exited 1, where before it would have passed with a note.

## Related

Three unresolved review comments on #603 each named a real defect, were missed at merge, and were rediscovered independently by the audit; they are fixed here and the threads are answered. The comment on #604 is superseded by the release-lag rule above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)