### PR TITLE
fix(ci): give the key-role idempotency job an Ansible that outlives the installer

### DIFF
--- a/.github/workflows/scenarios-ubuntu2404.yml
+++ b/.github/workflows/scenarios-ubuntu2404.yml
@@ -557,15 +557,51 @@ jobs:
       - name: Install baseline OVOS instance
         run: sudo -E env ANSIBLE_CALLBACKS_ENABLED="profile_tasks,timer" REUSE_CACHED_ARTIFACTS=true bash setup.sh
 
+      # Replaying the roles needs an Ansible that outlives the installer. setup.sh builds
+      # its own in ~/.venvs/ovos-installer and removes it unconditionally on success, so
+      # the binary this step used to insist on never exists by the time it runs.
+      #
+      # A virtualenv rather than a --user install, because the replay runs the playbook
+      # under sudo and sudo resets HOME to /root: anything installed into the runner's
+      # user site-packages is invisible to root, while a virtualenv carries its own and
+      # does not care whose HOME is set. The versions are the ones utils/common.sh pins
+      # for the installer, so the replay exercises the same Ansible that installed.
+      - name: Build the Ansible used to replay the roles
+        shell: bash
+        run: |
+          python3 -m venv "${GITHUB_WORKSPACE}/.ansible-replay"
+          "${GITHUB_WORKSPACE}/.ansible-replay/bin/pip" install --quiet --upgrade pip
+          "${GITHUB_WORKSPACE}/.ansible-replay/bin/pip" install --quiet \
+            "ansible==10.7.0" "docker==7.1.0" "requests==2.32.5"
+
       - name: Assert key role idempotency
         shell: bash
         run: |
           set -o pipefail
-          ansible_playbook_bin="$HOME/.venvs/ovos-installer/bin/ansible-playbook"
+          ansible_playbook_bin="${GITHUB_WORKSPACE}/.ansible-replay/bin/ansible-playbook"
           if [ ! -x "$ansible_playbook_bin" ]; then
-            echo "ansible-playbook not found at $ansible_playbook_bin"
+            echo "the replay virtualenv has no ansible-playbook at $ansible_playbook_bin"
             exit 1
           fi
+          # setup.sh installs the collections into the working copy and leaves them
+          # there; only /root/.ansible and its own virtualenv are removed. Under sudo the
+          # default search starts at /root and finds neither, so the path is named here -
+          # both candidates, because this job's cache restores the workspace copy and the
+          # home copy and either may be the populated one.
+          export ANSIBLE_COLLECTIONS_PATH="${GITHUB_WORKSPACE}/.ansible/collections:${HOME}/.ansible/collections"
+          found=""
+          for candidate in "${GITHUB_WORKSPACE}/.ansible/collections" "${HOME}/.ansible/collections"; do
+            if [ -d "${candidate}/ansible_collections" ]; then
+              echo "collections: ${candidate}"
+              found="yes"
+            fi
+          done
+          if [ -z "$found" ]; then
+            echo "the baseline install left no collections in either candidate path;"
+            echo "the replay would fail on the first role that uses one"
+            exit 1
+          fi
+          echo "replaying the key roles with ${ansible_playbook_bin}"
 
           key_roles=(ovos_facts ovos_config ovos_virtualenv ovos_services ovos_finalize)
           mkdir -p artifacts
@@ -574,6 +610,7 @@ jobs:
             role_log="artifacts/idempotency-${role_tag}.log"
             sudo -E env \
               ANSIBLE_CONFIG=ansible.cfg \
+              ANSIBLE_COLLECTIONS_PATH="$ANSIBLE_COLLECTIONS_PATH" \
               ANSIBLE_CALLBACKS_ENABLED="profile_tasks,timer" \
               "$ansible_playbook_bin" -i 127.0.0.1, ansible/site.yml \
                 -e "ovos_installer_user=${USER}" \

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ doc/_build/
 .theia
 .venv/
 .ansible
+.ansible-replay/
 __pycache__
 
 # Created by unit tests


### PR DESCRIPTION
`linux-key-role-idempotency` has **never once performed its assertion**. It is red on every scheduled run, and has been since it was written.

Its first line requires `~/.venvs/ovos-installer/bin/ansible-playbook`. `setup.sh:312` removes that virtualenv unconditionally on a successful run — so by the time the step executes, the binary it insists on has been deleted by the install it just performed:

```
ansible-playbook not found at /home/runner/.venvs/ovos-installer/bin/ansible-playbook
##[error]Process completed with exit code 1.
```

A job written to prove the key roles are idempotent therefore dies before comparing anything. `REUSE_CACHED_ARTIFACTS` does not help — it governs reusing the virtualenv at creation, not whether it is torn down.

## The fix

The replay builds its own Ansible, pinned to the versions `utils/common.sh` uses for the installer (`ansible==10.7.0`, `docker==7.1.0`, `requests==2.32.5`), so the roles are replayed with the same Ansible that installed them.

**A virtualenv rather than a `--user` install.** The replay runs the playbook under `sudo`, and `sudo -E` still resets `HOME=/root`, so anything in the runner's user site-packages is invisible to root. My first attempt used the repo's existing `install_ansible_requirements.sh` and failed exactly there:

```
ModuleNotFoundError: No module named 'ansible'
```

A virtualenv carries its own site-packages and does not care whose `HOME` is set.

**The collections are named explicitly**, for the same reason: under sudo the default search starts at `/root` and finds neither copy. Both candidates are listed, because this job's cache restores `.ansible/collections` *and* `~/.ansible/collections` and either may be the populated one — naming only the workspace would have excluded them in the case where the cache had filled the other. That was a real defect in my first version, caught by rehearsing it. If neither holds any collections the step says so, rather than failing later on whichever role first needs one.

## Verification

Rehearsed end to end on a real machine before committing — the virtualenv's `ansible-playbook`, under `sudo` with `HOME=/root`, resolving the real collection set, parsing the whole playbook:

```
syntax-check rc=0
```

`ansible-lint` (production) and 171 bats tests pass. `.gitignore` covers the replay virtualenv so a local run cannot commit it.

Found while auditing which CI jobs should carry the new intent round-trip check (#608). It is filed separately because it changes no installer behaviour and stands on its own.

One thing this does not do: it does not assert the job now *passes*. Whether the five key roles actually are idempotent within `OVOS_CI_MAX_ROLE_CHANGED=2` has never been measured, because the comparison has never run. The first scheduled run after this merges is the first real data — and it may well be red for a genuine reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of Linux key-role idempotency checks by using a dedicated Ansible environment for replay validation.
  - Enhanced collection path detection and validation during replay checks.

- **Chores**
  - Added the temporary Ansible replay environment to ignored files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->