### PR TITLE
fix(ci): stop the satellite job reporting itself as a real install

### DIFF
--- a/.github/workflows/scenarios-ubuntu2404.yml
+++ b/.github/workflows/scenarios-ubuntu2404.yml
@@ -732,6 +732,18 @@ jobs:
         run: |
           mkdir -p "$HOME/.config/ovos-installer"
           cp scenarios/scenario-satellite.yml "$HOME/.config/ovos-installer/scenario.yaml"
+
+          # The shipped scenario has telemetry on, because it is an example written for
+          # someone installing a real satellite. Copying it verbatim made every pull
+          # request and every push post a genuine install event: a runner in a US
+          # datacentre, reported as a container satellite on Ubuntu 24.04, several times
+          # an hour. Every other scenario in this file sets these false inline, and this
+          # one was missed precisely because it reuses the file rather than writing one.
+          sed -i 's/^share_telemetry: true$/share_telemetry: false/' \
+                 "$HOME/.config/ovos-installer/scenario.yaml"
+          sed -i 's/^share_usage_telemetry: true$/share_usage_telemetry: false/' \
+                 "$HOME/.config/ovos-installer/scenario.yaml"
+          grep -E '^share_(usage_)?telemetry:' "$HOME/.config/ovos-installer/scenario.yaml"
           cat "$HOME/.config/ovos-installer/scenario.yaml"
 
       - name: Run the satellite install

--- a/tests/bats/code_quality.bats
+++ b/tests/bats/code_quality.bats
@@ -3958,6 +3958,48 @@ function teardown() {
     refute_output --partial "[1:]"
 }
 
+@test "no_ci_job_reports_a_real_install_to_telemetry" {
+    # A CI run is not an install. The satellite job copied the shipped example scenario
+    # verbatim, and that example has telemetry on because it is written for somebody
+    # installing a real satellite - so every pull request and every push posted a genuine
+    # install event, several times an hour, indistinguishable in the dashboard from a
+    # person actually installing one.
+    #
+    # Checked by value rather than by counting occurrences: a scenario that names the
+    # setting at all must name it false, wherever a workflow writes or edits one.
+    for workflow in .github/workflows/scenarios-ubuntu2404.yml \
+                    .github/workflows/scenarios-archlinux.yml \
+                    .github/workflows/macos_ci.yml; do
+        [ -f "$workflow" ] || continue
+        run grep -nE '^[[:space:]]*share_(usage_)?telemetry: true' "$workflow"
+        assert_output ""
+    done
+
+    # Every shipped scenario keeps telemetry on - they are advice to real users, not test
+    # fixtures - so any workflow that copies one has to turn it off afterwards. Stated
+    # over whichever files are actually copied, so adding a job that reuses a different
+    # scenario is covered without anyone remembering this test exists.
+    # Scoped to the copying step, not merely to the file: every workflow here already
+    # contains "share_telemetry: false" somewhere, in the scenarios it writes inline, so
+    # a file-wide grep passes while the copied scenario still reports.
+    while read -r workflow; do
+        run awk '
+            /^[[:space:]]*cp scenarios\/.*\.yml/ { copying = 1; next }
+            copying && /share_telemetry: false/   { off = 1 }
+            copying && /^[[:space:]]*- name:/     { copying = 0 }
+            END { print (off ? "disabled" : "REPORTS") }
+        ' "$workflow"
+        assert_output "disabled"
+    done < <(grep -rlE '^[[:space:]]*cp scenarios/.*\.yml' .github/workflows/ || true)
+
+    # And the substitution has to still match the file it edits: rename the key upstream
+    # and the sed silently does nothing, which is how this got missed the first time.
+    run grep -qE '^share_telemetry: true$' scenarios/scenario-satellite.yml
+    assert_success
+    run grep -qE '^share_usage_telemetry: true$' scenarios/scenario-satellite.yml
+    assert_success
+}
+
 @test "contract_checker_decision_logic_and_reporting_are_tested_offline" {
     # Two suites, both offline, discovered by pattern rather than by name so that adding a
     # third does not silently go unrun - which is what happened to the reporting suite, whose


### PR DESCRIPTION
The telemetry dashboard is showing CI runs as installs. Every row is the same shape — **Satellite / Container / Testing / Ubuntu 24.04 / x86_64 / United States** — arriving every few minutes.

## Why

`linux-satellite-scenario` copies the scenario this repository ships:

```
cp scenarios/scenario-satellite.yml "$HOME/.config/ovos-installer/scenario.yaml"
```

and `scenarios/scenario-satellite.yml` has:

```yaml
share_telemetry: true
share_usage_telemetry: true
```

Correctly so — it is an example written for somebody installing a real satellite. But copied verbatim into CI it means every pull request and every push posts a genuine install event, indistinguishable in the dashboard from a person installing one. That job runs on `pull_request` and `push`, not only on a schedule, and there were **35 workflow runs today alone**.

Every other scenario in that workflow sets both flags `false` inline. This job was missed **precisely because it reuses the shipped file** instead of writing its own — there was no inline setting for anyone to notice.

## The fix

The example keeps telemetry on; the job turns it off after copying, and prints the result so a run shows what it applied. That way the advice given to a real user is not shaped by what the tests need.

## The guard

Three things, each mutation-tested:

- **No CI scenario may set telemetry `true`** — anywhere in the ubuntu, arch or macOS workflows.
- **Any step that copies a shipped scenario must disable telemetry.** Scoped to the step, not the file: every one of these workflows already contains `share_telemetry: false` somewhere in the scenarios it writes inline, so a file-wide grep passes while the copied scenario still reports. My first version of this guard made exactly that mistake and let the mutation through.
- **The keys the substitution matches must still exist upstream.** Rename one in the example and the `sed` silently matches nothing — the same shape of silent no-op that caused this in the first place.

Only `scenario-satellite.yml` is copied by a workflow today, but all four shipped scenarios have telemetry on, so the guard is written over whichever files are actually copied rather than naming that one.

## Not addressed here

The events already recorded. If the satellite installs logged since this job was added should be purged or filtered out of the dashboard, that needs a decision and access I do not have.

`ansible-lint` (production) and 175 bats tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)