### PR TITLE
fix(telemetry): do not report an automated run as an install

### DIFF
--- a/ansible/roles/ovos_telemetry/defaults/main.yml
+++ b/ansible/roles/ovos_telemetry/defaults/main.yml
@@ -7,3 +7,52 @@ ovos_telemetry_geoip_url: http://ip-api.com/json
 ovos_telemetry_url: "https://telemetry.smartgic.io/ovos-installer/metrics/"
 ovos_telemetry_user_agent: "OVOS-Installer/1.0 (Ansible)"
 ovos_telemetry_validate_certs: false
+
+# A continuous integration run is indistinguishable from a real install by the time this
+# role sees it: same distribution, same architecture, same everything the payload carries.
+# The only thing that separates them is the environment the runner exports, so that is
+# what is tested.
+#
+# A guard belongs here rather than in any one workflow because a workflow fix reaches only
+# the repository it is committed to. When this installer's own CI began installing a
+# satellite on every push, it reported sixty installs in nine days; correcting that
+# workflow stopped it upstream while forks running their own copy carried on reporting.
+# Checked at the point of sending, it covers every caller - scenario, TUI, arguments, fork.
+ovos_telemetry_ci_markers:
+  - CI
+  - GITHUB_ACTIONS
+  - GITLAB_CI
+  - JENKINS_URL
+  - BUILDKITE
+  - CIRCLECI
+  - TRAVIS
+  - TEAMCITY_VERSION
+  - TF_BUILD
+  - BITBUCKET_BUILD_NUMBER
+  - DRONE
+  - APPVEYOR
+
+# Presence is not the test: several tools export CI=false to mean the opposite.
+ovos_telemetry_ci_falsey_values:
+  - ""
+  - "false"
+  - "0"
+  - "no"
+  - "off"
+
+# Read from the environment rather than from ansible_env, which only exists once facts
+# have been gathered - site.yml sets gather_facts: false, so a facts-based test reports
+# "not CI" on a runner that plainly is one, and telemetry goes out anyway.
+ovos_telemetry_ci_markers_set: >-
+  {{ ovos_telemetry_ci_markers
+     | zip(q('env', *ovos_telemetry_ci_markers) | map('string') | map('trim') | map('lower'))
+     | rejectattr('1', 'in', ovos_telemetry_ci_falsey_values)
+     | map('first') | list }}
+
+ovos_telemetry_ci_detected: "{{ (ovos_telemetry_ci_markers_set | length) > 0 }}"
+
+# For someone deliberately exercising the telemetry path from a pipeline.
+ovos_telemetry_allow_in_ci: false
+
+ovos_telemetry_should_share: >-
+  {{ (not (ovos_telemetry_ci_detected | bool)) or (ovos_telemetry_allow_in_ci | bool) }}

--- a/ansible/roles/ovos_telemetry/tasks/main.yml
+++ b/ansible/roles/ovos_telemetry/tasks/main.yml
@@ -4,7 +4,17 @@
   tags:
     - always
 
+- name: Report that telemetry is withheld because this is an automated run
+  ansible.builtin.debug:
+    msg: >-
+      Telemetry was not shared: this looks like a continuous integration run
+      ({{ ovos_telemetry_ci_markers_set | join(', ') }} set in the environment). A build
+      is not a user, and counting one as an install misreports the community figures.
+      Set ovos_telemetry_allow_in_ci to true to send anyway.
+  when: not (ovos_telemetry_should_share | bool)
+
 - name: Block telemetry
+  when: ovos_telemetry_should_share | bool
   block:
     - name: Retrieve country based on ISP address
       ansible.builtin.uri:

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -10,6 +10,13 @@ The installer sends one payload to `https://telemetry.smartgic.io/ovos-installer
 
 To fill the `country` field, the installer asks `http://ip-api.com/json` to look up the location of the host. That request tells a third-party service your IP address, and it goes over plain HTTP, so anything on the path can read it. Decline installer telemetry if you do not want that lookup to happen.
 
+Automated runs are not counted. When the installer finds a continuous integration
+marker in the environment - `CI`, `GITHUB_ACTIONS`, `GITLAB_CI` and the equivalents for
+the other common systems - it skips this payload and says so, because a build is not a
+user and counting one as an install misreports the community figures. A variable set to
+`false` or left empty is read as "not CI", so ordinary machines are unaffected. Set
+`ovos_telemetry_allow_in_ci` to `true` to report from a pipeline on purpose.
+
 The table below lists the collected data. See the [Ansible task](https://github.com/OpenVoiceOS/ovos-installer/blob/main/ansible/roles/ovos_telemetry/tasks/main.yml) that builds and sends the telemetry payload.
 
 | Data                    | Description                                             |

--- a/tests/bats/code_quality.bats
+++ b/tests/bats/code_quality.bats
@@ -1778,6 +1778,77 @@ function setup() {
     assert_success
 }
 
+@test "telemetry_is_withheld_from_continuous_integration_runs" {
+    # A build is not a user. This installer's own CI reported sixty satellite installs in
+    # nine days before anyone noticed, and correcting that workflow only fixed the one
+    # repository - forks run the same workflow from their own copy and kept reporting.
+    # So the refusal lives at the point of sending, where every caller passes through it.
+    #
+    # Asserted by running the decision, not by reading it: the earlier version of this
+    # guard read ansible_env, which is populated only once facts are gathered. site.yml
+    # gathers none, so that version answered "not CI" on a runner that plainly was one
+    # and telemetry went out anyway. A grep for the variable name would still have passed.
+    run grep -q "gather_facts: false" ansible/site.yml
+    assert_success
+
+    local defaults_file="$PWD/ansible/roles/ovos_telemetry/defaults/main.yml"
+    local gate_playbook
+    gate_playbook="$(mktemp "${BATS_TEST_TMPDIR:-/tmp}/telemetry_ci_gate.XXXXXX.yml")"
+    cat >"$gate_playbook" <<YAML
+- hosts: localhost
+  gather_facts: false
+  tasks:
+    - ansible.builtin.include_vars:
+        file: "$defaults_file"
+    - ansible.builtin.assert:
+        that:
+          - (ovos_telemetry_should_share | bool) == (lookup('env', 'EXPECT_SHARE') == 'yes')
+        fail_msg: >-
+          should_share={{ ovos_telemetry_should_share }} but EXPECT_SHARE={{ lookup('env', 'EXPECT_SHARE') }}
+          (markers seen: {{ ovos_telemetry_ci_markers_set }})
+YAML
+
+    # This suite runs inside CI itself, so the workstation cases only mean anything with
+    # every marker cleared first.
+    local -a clean=(env)
+    local marker
+    for marker in CI GITHUB_ACTIONS GITLAB_CI JENKINS_URL BUILDKITE CIRCLECI TRAVIS \
+        TEAMCITY_VERSION TF_BUILD BITBUCKET_BUILD_NUMBER DRONE APPVEYOR; do
+        clean+=("-u" "$marker")
+    done
+
+    # A runner that announces itself is not counted.
+    run "${clean[@]}" CI=true EXPECT_SHARE=no ansible-playbook -i localhost, -c local "$gate_playbook"
+    assert_success
+    run "${clean[@]}" GITHUB_ACTIONS=true EXPECT_SHARE=no ansible-playbook -i localhost, -c local "$gate_playbook"
+    assert_success
+    run "${clean[@]}" GITLAB_CI=true EXPECT_SHARE=no ansible-playbook -i localhost, -c local "$gate_playbook"
+    assert_success
+
+    # CI=false is what several tools export to mean the opposite, so presence alone must
+    # not be the test - that reading would silence telemetry on ordinary machines.
+    run "${clean[@]}" CI=false EXPECT_SHARE=yes ansible-playbook -i localhost, -c local "$gate_playbook"
+    assert_success
+    run "${clean[@]}" CI= EXPECT_SHARE=yes ansible-playbook -i localhost, -c local "$gate_playbook"
+    assert_success
+
+    # With nothing set, a real install still reports. Without this case the guard would be
+    # indistinguishable from one that switched telemetry off for everybody.
+    run "${clean[@]}" EXPECT_SHARE=yes ansible-playbook -i localhost, -c local "$gate_playbook"
+    assert_success
+
+    # And someone deliberately exercising the telemetry path from a pipeline can still say so.
+    run "${clean[@]}" CI=true EXPECT_SHARE=yes ansible-playbook -i localhost, -c local \
+        -e ovos_telemetry_allow_in_ci=true "$gate_playbook"
+    assert_success
+
+    rm -f "$gate_playbook"
+
+    # The role must consult the decision rather than carry its own copy of it.
+    run grep -q "when: ovos_telemetry_should_share | bool" ansible/roles/ovos_telemetry/tasks/main.yml
+    assert_success
+}
+
 @test "sound_role_never_writes_invalid_n_a_asound_defaults" {
     local defaults_file="ansible/roles/ovos_sound/defaults/main.yml"
     local tasks_file="ansible/roles/ovos_sound/tasks/install.yml"


### PR DESCRIPTION
A build is not a user. When this installer's CI began installing a satellite on every push it reported **sixty installs in nine days** — all of them a runner in a US datacentre, reported as a container satellite on Ubuntu 24.04 — and the community dashboard counted every one.

#611 corrected the workflow, which fixed this repository and nothing else. Forks run the same workflow from their own copy, and one kept reporting after the fix landed: two of the polluted rows came from `Jahid11978/ovos-installer`, and another arrived minutes after the dashboard was cleaned.

So the refusal belongs at the point of sending, where every caller passes through it — scenario, TUI, arguments, fork.

## What it does

`ovos_telemetry` checks the environment for the markers CI systems export (`CI`, `GITHUB_ACTIONS`, `GITLAB_CI`, and the equivalents for nine others). If it finds one, it withholds the payload and says so rather than skipping silently. `ovos_telemetry_allow_in_ci` sends anyway, for someone exercising this path from a pipeline deliberately.

Presence alone is not the test: several tools export `CI=false` to mean the opposite, and reading that as a runner would silence telemetry on ordinary machines.

## The part that would have shipped broken

The obvious implementation reads `ansible_env`. `site.yml` sets `gather_facts: false`, so `ansible_env` is empty where this is evaluated and that version answers *"not CI"* on a runner that plainly is one — telemetry goes out anyway. A test that grepped for the variable name would still have passed.

Measured, not assumed:

```
gather_facts: false, CI=true  ->  via_facts=False   via_lookup=True
```

So the guard reads the environment directly, and the test runs the decision instead of reading it: `CI=true` and `GITHUB_ACTIONS=true` withhold; `CI=false`, `CI=` and an unset environment still report; the escape hatch still sends. It clears every marker first, because the suite itself runs in CI — without that the negative cases could not fail.

Mutation-tested against a green baseline, 7/7 caught: detection switched to `ansible_env`, decision inverted, telemetry disabled for everyone, falsey values no longer rejected, `GITHUB_ACTIONS` dropped from the markers, the block ungated, and `site.yml` flipping the premise out from under the test.

ansible-lint clean (production profile); 581 bats tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Installer telemetry is now automatically withheld during detected CI runs.
  - Common CI environment markers are recognized, with empty or false values ignored.
  - Telemetry can be explicitly enabled in CI using `ovos_telemetry_allow_in_ci=true`.
  - Telemetry tasks report when sharing is skipped, including detection details.

- **Documentation**
  - Added guidance explaining CI detection, suppression behavior, and the opt-in setting.

- **Tests**
  - Added coverage for CI suppression, explicit opt-in, and normal-machine telemetry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->