### PR TITLE
fix(ci): ask again when a restarting skill never hears the utterance

### DIFF
--- a/.github/scripts/assert_intent_roundtrip.py
+++ b/.github/scripts/assert_intent_roundtrip.py
@@ -145,7 +145,12 @@ def probe(bus, utterance, lang, timeout):
     return (answer.get("data") or {}).get("intent")
 
 
-def round_trip(bus, utterance, lang, timeout):
+# Long enough that a healthy skill answers on the first ask, short enough that a
+# dropped utterance is asked again several times inside a --speak-timeout budget.
+SPEAK_ATTEMPT_WINDOW = 20.0
+
+
+def round_trip(bus, utterance, lang, timeout, attempt_window=SPEAK_ATTEMPT_WINDOW):
     """An utterance in, speech out: the whole chain, with a skill on the end of it.
 
     The reply is correlated with this particular utterance rather than taken as the next
@@ -154,21 +159,40 @@ def round_trip(bus, utterance, lang, timeout):
     answer that never came. A skill answering inside a handler speaks with
     `message.forward`, which carries the triggering context through, so a marker put on
     the utterance comes back on the reply.
+
+    The utterance is asked again rather than waited on in one go, because a bus message is
+    fire-and-forget. A skills service that is not listening at that instant never receives
+    the one in flight, and waiting longer cannot recover a message nobody was there for -
+    only asking again can. That is not hypothetical: on macOS this service has been seen
+    to abort during boot and be relaunched, which leaves the intent resolving from core
+    while no skill answers, and a single-shot wait reports that as "nothing spoke" after
+    the full budget. Every attempt keeps its marker, so an answer to an earlier attempt
+    still counts rather than being discarded as unrecognised.
     """
-    marker = secrets.token_hex(8)
-    bus.send("recognizer_loop:utterance",
-             {"utterances": [utterance], "lang": lang},
-             {"source": ["ci"], "lang": lang, "ci_probe": marker})
-    answer = bus.wait_for(
-        "speak", timeout,
-        match=lambda m: (m.get("context") or {}).get("ci_probe") == marker)
-    if answer is None:
-        raise Failure(
-            f"nothing spoke within {timeout:.0f}s of saying {utterance!r}. The intent "
-            f"resolves, so core is working - what did not happen is a skill answering "
-            f"it, which is the half this exists to prove."
-        )
-    return (answer.get("data") or {}).get("utterance", "")
+    deadline = time.monotonic() + timeout
+    markers = set()
+    attempts = 0
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            break
+        marker = secrets.token_hex(8)
+        markers.add(marker)
+        attempts += 1
+        bus.send("recognizer_loop:utterance",
+                 {"utterances": [utterance], "lang": lang},
+                 {"source": ["ci"], "lang": lang, "ci_probe": marker})
+        answer = bus.wait_for(
+            "speak", min(attempt_window, remaining),
+            match=lambda m: (m.get("context") or {}).get("ci_probe") in markers)
+        if answer is not None:
+            return (answer.get("data") or {}).get("utterance", "")
+    raise Failure(
+        f"nothing spoke within {timeout:.0f}s of saying {utterance!r}, asked "
+        f"{attempts} time{'' if attempts == 1 else 's'}. The intent resolves, so core is "
+        f"working - what did not happen is a skill answering it, which is the half this "
+        f"exists to prove."
+    )
 
 
 def main(argv=None):
@@ -185,6 +209,10 @@ def main(argv=None):
                              "stack on a slow runner is the case this has to cover")
     parser.add_argument("--reply-timeout", type=float, default=30)
     parser.add_argument("--speak-timeout", type=float, default=60)
+    parser.add_argument("--speak-attempt-window", type=float,
+                        default=SPEAK_ATTEMPT_WINDOW,
+                        help="how long to wait for an answer before asking "
+                             "again, within the --speak-timeout budget.")
     parser.add_argument("--expect-match", action="store_true",
                         help="require the probe to resolve to an intent")
     parser.add_argument("--expect-pipeline", default=None,
@@ -246,7 +274,8 @@ def main(argv=None):
             )
 
         if args.expect_speak:
-            spoken = round_trip(bus, args.utterance, args.lang, args.speak_timeout)
+            spoken = round_trip(bus, args.utterance, args.lang, args.speak_timeout,
+                                args.speak_attempt_window)
             print(f"speech    : a skill answered with {spoken!r}")
 
         print("the bus, core and the skills are talking to each other")

--- a/.github/scripts/assert_intent_roundtrip.py
+++ b/.github/scripts/assert_intent_roundtrip.py
@@ -169,6 +169,15 @@ def round_trip(bus, utterance, lang, timeout, attempt_window=SPEAK_ATTEMPT_WINDO
     the full budget. Every attempt keeps its marker, so an answer to an earlier attempt
     still counts rather than being discarded as unrecognised.
     """
+    # A window that is not positive makes every wait return at once, and the loop below
+    # then re-asks as fast as the socket allows - a three second budget sent the
+    # utterance 467,438 times. nan fails this test too, because nan > 0 is False, and it
+    # would otherwise poison min() and leave the wait with no deadline at all. Positive
+    # infinity is fine: min() then yields the remaining budget.
+    if not attempt_window > 0:
+        raise Failure(
+            f"--speak-attempt-window must be greater than zero, not {attempt_window!r}."
+        )
     deadline = time.monotonic() + timeout
     markers = set()
     attempts = 0

--- a/.github/workflows/macos_ci.yml
+++ b/.github/workflows/macos_ci.yml
@@ -340,6 +340,15 @@ jobs:
           launchctl list | grep -E 'ovos|hivemind' || true
           ls -la "$HOME/Library/LaunchAgents" || true
           ls -la "$HOME/.local/state/mycroft/logs" || true
+          # Listing these was not enough. When the round trip failed because no skill
+          # answered, the launchctl line above said com.ovos.service had last exited -6 -
+          # it had aborted and been relaunched - and the reason was in ovos-core.err,
+          # which nothing printed. The one question the step exists to answer needs the
+          # service's own output, not a directory listing of it.
+          for log in ovos-core.err ovos-core.log ovos-audio.err ovos-audio.log; do
+            printf '\n===== %s =====\n' "$log"
+            tail -n 200 "$HOME/.local/state/mycroft/logs/$log" || true
+          done
           # The installer tells you to read this file when it gives up, so it
           # belongs in the job output. Without it a CI failure is undebuggable.
           sudo tail -n 200 /var/log/ovos-installer.log || true

--- a/scripts/test_intent_roundtrip.py
+++ b/scripts/test_intent_roundtrip.py
@@ -40,6 +40,8 @@ MATCH = {"intent_name": "stop:global",
          "intent_service": "ovos-stop-pipeline-plugin-high",
          "skill_id": "stop.openvoiceos"}
 
+DROPPED = [0]
+
 async def handler(ws):
     async for raw in ws:
         m = json.loads(raw)
@@ -66,6 +68,28 @@ async def handler(ws):
         elif kind == "recognizer_loop:utterance":
             if MODE == "silent_skill":
                 continue
+            if MODE == "slow_skill":
+                # Answers the utterance it was given, but slowly enough that the harness
+                # has already asked again by the time it speaks. The reply carries the
+                # FIRST ask's marker, and it is still the answer to the question.
+                ctx_slow = dict(m.get("context") or {})
+                async def answer_later(c):
+                    await asyncio.sleep(3)
+                    await ws.send(json.dumps({"type": "speak",
+                                              "data": {"utterance": "it is half past ten"},
+                                              "context": c}))
+                if DROPPED[0] == 0:
+                    DROPPED[0] += 1
+                    asyncio.create_task(answer_later(ctx_slow))
+                continue
+            if MODE == "restarting_skill":
+                # A skills service that is being relaunched is simply not there for the
+                # utterance in flight. Dropping the first two and answering the third is
+                # what that looks like from the bus: nothing is refused, nothing errors,
+                # the message just lands where no one is listening.
+                DROPPED[0] += 1
+                if DROPPED[0] <= 2:
+                    continue
             if MODE == "chatty_bystander":
                 # another skill talking on its own account: no triggering context, so no
                 # marker - exactly what must NOT be mistaken for the answer
@@ -125,11 +149,12 @@ class FakeBus:
                 self.proc.kill()
 
 
-def run_harness(*args, port):
+def run_harness(*args, port, speak_timeout="4", attempt_window="20"):
     result = subprocess.run(
         [sys.executable, str(HARNESS), "--url", f"ws://127.0.0.1:{port}/core",
          "--connect-timeout", "4", "--ready-timeout", "6",
-         "--reply-timeout", "4", "--speak-timeout", "4", *args],
+         "--reply-timeout", "4", "--speak-timeout", speak_timeout,
+         "--speak-attempt-window", attempt_window, *args],
         capture_output=True, text=True, timeout=90)
     return result.returncode, result.stdout + result.stderr
 
@@ -188,6 +213,35 @@ class EachRungCanFail(unittest.TestCase):
             code, out = run_harness("--expect-speak", port=bus.port)
         self.assertEqual(code, 1, out)
         self.assertIn("a skill answering it", out)
+
+    def test_an_utterance_dropped_by_a_restarting_skill_is_asked_again(self):
+        """Waiting longer cannot recover a message nobody was listening for.
+
+        A bus utterance is fire-and-forget. When the skills service aborts and launchd
+        relaunches it - which is what macOS was doing when this rung failed, with the
+        intent still resolving from core - the utterance in flight is simply lost. A
+        single-shot wait then reports "nothing spoke" after the whole budget, having
+        asked exactly once. Only asking again recovers it.
+        """
+        with FakeBus("restarting_skill") as bus:
+            code, out = run_harness("--expect-speak", port=bus.port,
+                                    speak_timeout="24", attempt_window="2")
+            self.assertEqual(code, 0, out)
+            self.assertIn("a skill answered with", out)
+
+    def test_a_late_answer_to_an_earlier_ask_still_counts(self):
+        """Asking again must not invalidate the question already asked.
+
+        The reply carries the marker of the ask it belongs to. If only the newest marker
+        were accepted, a skill that answered the first ask a moment after the harness had
+        moved on would be thrown away as somebody else's speech, and a deployment that
+        works would be reported as one where no skill answered.
+        """
+        with FakeBus("slow_skill") as bus:
+            code, out = run_harness("--expect-speak", port=bus.port,
+                                    speak_timeout="24", attempt_window="2")
+            self.assertEqual(code, 0, out)
+            self.assertIn("half past ten", out)
 
     def test_the_skills_rung_can_be_skipped_for_a_profile_that_runs_none(self):
         with FakeBus("healthy") as bus:

--- a/scripts/test_intent_roundtrip.py
+++ b/scripts/test_intent_roundtrip.py
@@ -154,7 +154,7 @@ def run_harness(*args, port, speak_timeout="4", attempt_window="20"):
         [sys.executable, str(HARNESS), "--url", f"ws://127.0.0.1:{port}/core",
          "--connect-timeout", "4", "--ready-timeout", "6",
          "--reply-timeout", "4", "--speak-timeout", speak_timeout,
-         "--speak-attempt-window", attempt_window, *args],
+         f"--speak-attempt-window={attempt_window}", *args],
         capture_output=True, text=True, timeout=90)
     return result.returncode, result.stdout + result.stderr
 
@@ -242,6 +242,24 @@ class EachRungCanFail(unittest.TestCase):
                                     speak_timeout="24", attempt_window="2")
             self.assertEqual(code, 0, out)
             self.assertIn("half past ten", out)
+
+    def test_an_attempt_window_that_is_not_positive_is_refused(self):
+        """Otherwise the re-ask loop becomes a flood.
+
+        A window of zero makes every wait return immediately, so the loop re-sends as
+        fast as the socket allows: a three second budget sent the utterance 467,438
+        times. nan is refused for the same reason - nan > 0 is False - and because it
+        would poison min() and leave the wait with no deadline. Positive infinity is
+        allowed, since min() then yields the remaining budget.
+        """
+        for window in ("0", "-1", "nan", "-inf"):
+            with self.subTest(window=window):
+                with FakeBus("silent_skill") as bus:
+                    code, out = run_harness("--expect-speak", port=bus.port,
+                                            speak_timeout="3", attempt_window=window)
+                    self.assertEqual(code, 1, out)
+                    self.assertIn("must be greater than zero", out)
+                    self.assertNotIn("asked", out)
 
     def test_the_skills_rung_can_be_skipped_for_a_profile_that_runs_none(self):
         with FakeBus("healthy") as bus:


### PR DESCRIPTION
`macos-scenario-matrix (macos-15-intel, testing, ovos, all)` failed on main with:

```
intent round trip failed: nothing spoke within 120s of saying 'what time is it'.
The intent resolves, so core is working - what did not happen is a skill answering it.
```

## Why

The launchctl output in the same job already said it, or nearly:

```
23144   -6   com.ovos.service
```

The skills service had **aborted** and been relaunched. A bus utterance is fire-and-forget: the one in flight lands where nobody is listening, and no amount of waiting recovers a message that was never received. The harness sent once and waited the full 120s, so a service that was restarting for two of those seconds failed the whole rung.

## What changed

`round_trip` now asks again inside the same `--speak-timeout` budget (`--speak-attempt-window`, default 20s). Every ask keeps its marker, so a skill that answers the *first* ask a moment after the harness has moved on still counts — accepting only the newest marker would throw that away and report a working deployment as a broken one.

Correlation is otherwise untouched: an unprompted boot announcement still cannot stand in for a reply.

The diagnostics step listed `~/.local/state/mycroft/logs` without printing anything in it, which is precisely why the `-6` went unexplained. It now dumps `ovos-core.err`/`.log` and `ovos-audio.err`/`.log` — the one question that step exists to answer lives in the service's own output.

## Proof

Two new tests drive a fake bus that reproduces each case: one that drops the first two utterances the way a relaunching service does, and one that answers the first ask late, after the harness has already asked again.

Mutation-tested against a green baseline:

| mutation | result |
|---|---|
| re-ask removed (the original single-shot wait) | CAUGHT |
| only the newest marker accepted | CAUGHT |
| correlation dropped (any `speak` accepted) | CAUGHT |

80 unit tests, 582 bats tests, ansible-lint clean.

## Note

This makes the rung survive the restart; it does not explain the `SIGABRT` itself. With the diagnostics fix, the next occurrence will carry the traceback in the job output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved speech interaction reliability by retrying utterances when responses are delayed or a service restarts.
  - Late responses from earlier attempts are now recognized correctly.
  - Failure messages now include the number of attempts made.

- **Chores**
  - Added configuration for the per-attempt speech response window.
  - macOS diagnostic output now includes recent core and audio service logs to aid troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->